### PR TITLE
Add pyproject.toml with canonical pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.pytest.ini_options]
+markers = [
+    "unit: pure logic tests, no external dependencies",
+    "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
+    "integration: needs external service or fixture data",
+    "e2e: full pipeline end-to-end test",
+    "parity: old vs new implementation comparison",
+    "slow: marks tests as slow",
+]
+addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"
+testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Adds a minimal `pyproject.toml` carrying the canonical 6-marker WXYC ETL block (`unit`, `postgres`, `integration`, `e2e`, `parity`, `slow`) defined in the org-local `plans/test-patterns.md`. Includes the standard `addopts` so `pytest` with no arguments runs only unit tests, matching the convention used by the other ETL repos.

This repo is Rust-primary with a small auxiliary Python test layer (`tests/conftest.py`, `tests/unit/test_filter_artists_rust.py`, `tests/integration/test_import_pipeline.py`). Until now there was no `pyproject.toml` so pytest had no marker definitions or default-deselect behavior. CI runs only `cargo` jobs; this configuration is for local pytest invocations.

Part of WXYC/wxyc-etl#23 (test pattern standardization across ETL repos). PR-A4 of the planned chain.

## Test plan

- [x] `pytest --markers` lists all 6 canonical markers
- [x] `pytest -m unit --co` no longer reports an unknown-marker warning
- [x] No change to Rust CI (`cargo fmt`, `cargo clippy`, `cargo test`, `test-postgres`)
- [x] Rebased onto main after #13 merged; all CI green

This is the final sub-PR closing the test-pattern standardization issue:

Closes WXYC/wxyc-etl#23