### PR TITLE
Include mb_release in TRUNCATE to satisfy FK constraint

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -194,14 +194,21 @@ pub fn prune_to_matching(
 
     // Phase 2: Truncate all tables in one statement.
     //
-    // `mb_release` is included even though we don't import or filter it: the schema
-    // declares an FK from `mb_release.artist_credit` to `mb_artist_credit(id)`, and
+    // The tables below are included even though we don't import or filter them:
     // PostgreSQL refuses to TRUNCATE a referenced table unless every referencing
-    // table is in the same TRUNCATE statement. Listing it here keeps the table
-    // empty (its production state) and satisfies PG's atomic FK check.
+    // table is in the same TRUNCATE statement, regardless of whether the
+    // referencing table has any rows. Listing them here keeps them empty (their
+    // production state) and satisfies PG's atomic FK check.
+    //
+    //   - mb_release             -> references mb_artist_credit, mb_release_group
+    //   - mb_l_release_group_url -> references mb_release_group
+    //   - mb_l_release_url       -> references mb_release
+    //
+    // None of these are present in `TABLES` (src/import.rs) or in the swaps list,
+    // so they remain empty after this TRUNCATE.
     log::info!("Phase 2: truncating tables...");
     let mut all_tables: Vec<&str> = swaps.iter().map(|(t, _, _)| t.as_str()).collect();
-    all_tables.push("mb_release");
+    all_tables.extend(["mb_release", "mb_l_release_group_url", "mb_l_release_url"]);
     client.batch_execute(&format!("TRUNCATE {}", all_tables.join(", ")))?;
 
     // Phase 3: Re-insert kept rows.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -193,8 +193,15 @@ pub fn prune_to_matching(
     swaps.push(save_kept(client, "mb_gender", "TRUE")?);
 
     // Phase 2: Truncate all tables in one statement.
+    //
+    // `mb_release` is included even though we don't import or filter it: the schema
+    // declares an FK from `mb_release.artist_credit` to `mb_artist_credit(id)`, and
+    // PostgreSQL refuses to TRUNCATE a referenced table unless every referencing
+    // table is in the same TRUNCATE statement. Listing it here keeps the table
+    // empty (its production state) and satisfies PG's atomic FK check.
     log::info!("Phase 2: truncating tables...");
-    let all_tables: Vec<&str> = swaps.iter().map(|(t, _, _)| t.as_str()).collect();
+    let mut all_tables: Vec<&str> = swaps.iter().map(|(t, _, _)| t.as_str()).collect();
+    all_tables.push("mb_release");
     client.batch_execute(&format!("TRUNCATE {}", all_tables.join(", ")))?;
 
     // Phase 3: Re-insert kept rows.


### PR DESCRIPTION
## Summary

The schema declares an FK from \`mb_release.artist_credit\` to \`mb_artist_credit(id)\`. PostgreSQL refuses to \`TRUNCATE\` a referenced table unless every referencing table is in the same \`TRUNCATE\` statement, regardless of whether the referencing table has any rows.

\`mb_release\` is not imported or filtered (no entry in \`TABLES\` in \`src/import.rs\` and no \`save_kept\` call in \`src/filter.rs\`), so it is always empty in production. Adding it to the \`TRUNCATE\` list keeps it empty and satisfies PG's atomic FK check.

## Why now

Three \`test_prune_*\` tests in \`tests/filter_test.rs\` have been failing on \`main\` since the last commit (\`bcb94bf\`, 2026-04-14):

- \`test_prune_to_matching\`
- \`test_prune_orphaned_tags\`
- \`test_prune_orphaned_areas\`

All three fail with the same error:

\`\`\`
ERROR: cannot truncate a table referenced in a foreign key constraint
DETAIL: Table "mb_release" references "mb_artist_credit".
HINT:  Truncate table "mb_release" at the same time, or use TRUNCATE ... CASCADE.
\`\`\`

This PR follows the HINT's first suggestion (truncate \`mb_release\` at the same time) rather than \`CASCADE\`. \`CASCADE\` would silently drop rows from any future referencing table — explicit listing keeps the contract visible.

## Test plan

- [ ] CI green (lint, test, test-postgres) — local verification not possible because the worktree breaks the \`../../../wxyc-etl\` relative path dependency
- [ ] The three \`test_prune_*\` failures resolve

## Future-proofing

If \`mb_release\` ever starts being imported, the swaps logic should be updated to include a \`save_kept\` call for it (e.g., keep releases whose \`artist_credit\` is in \`_kept_mb_artist_credit\`). The comment in the diff makes that intent explicit.