### PR TITLE
Restore dropped Unicode test cases now that canonical pool covers ñ / multi-diacritic / capital-Ö

### DIFF
--- a/tests/unit/test_filter_artists_rust.py
+++ b/tests/unit/test_filter_artists_rust.py
@@ -65,6 +65,9 @@ class TestNormalizeParity:
             "Nilüfer Yanya",  # ü
             "Hermanos Gutiérrez",  # é
             "Csillagrablók",  # ó
+            "Sonido Dueñez",  # ñ — combining-tilde decomposition (canonical via @wxyc/shared#81)
+            "Aşıq Altay",  # multi-diacritic Turkish (ş + ı; canonical via @wxyc/shared#81)
+            "GIDEÖN",  # capital Ö mid-word (canonical via @wxyc/shared#84)
             # Combining characters (NFD form of canonical names)
             "Nilu\u0308fer Yanya",  # 'u' + combining diaeresis (NFD of Nilüfer Yanya)
             "Hermanos Gutie\u0301rrez",  # 'e' + combining acute (NFD of Gutiérrez)


### PR DESCRIPTION
Closes #16. Depends conceptually on WXYC/wxyc-shared#81 and WXYC/wxyc-shared#84 (which add Sonido Dueñez, Aşıq Altay, and GIDEÖN to `wxycCanonicalArtistNames`); the test uses string literals so it runs identically without those merging.

## Summary

#12 dropped Unicode parametrize cases for ñ, multi-diacritic single names, and capital-diacritic-mid-word because the canonical pool had no analogue. Now that the pool covers all three shapes, this restores the coverage with canonical names: **Sonido Dueñez** (ñ), **Aşıq Altay** (multi-diacritic Turkish ş + ı), **GIDEÖN** (capital Ö mid-word).

## Test plan

- [x] `pytest tests/unit/test_filter_artists_rust.py --collect-only` — collects 28 tests (was 25)
- [ ] CI passes (the new entries run under the `python-wheel` job equivalent — `test-postgres` plus the wxyc-etl-python install in the local pytest harness)