### PR TITLE
Consume PipelineState in main.rs and add --resume flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Rust binary that builds a WXYC-filtered MusicBrainz cache database. Downloads Mu
 
 ## Architecture
 
-- `src/main.rs` -- CLI orchestrator (clap). Coordinates the pipeline: download -> schema -> import -> filter -> indexes -> analyze.
+- `src/main.rs` -- CLI orchestrator (clap). Coordinates the pipeline: download -> schema -> import -> filter -> indexes -> analyze. Consumes `PipelineState` (see Resume) so `--resume` skips already-completed steps.
 - `src/download.rs` -- HTTP download (`reqwest`) and tar.bz2 extraction (parallel `lbzip2`/`pbzip2` with Rust `bzip2`+`tar` fallback).
 - `src/import.rs` -- TSV import. Reads headerless MusicBrainz dump files, extracts columns by positional index, streams to PostgreSQL via COPY.
 - `src/filter.rs` -- Artist filtering. Loads WXYC library.db (SQLite), matches by normalized name + aliases, prunes via copy-and-swap.
@@ -54,6 +54,19 @@ Uses copy-and-swap instead of DELETE to avoid dead tuples. Steps:
 3. TRUNCATE all tables together (satisfies FK constraints)
 4. Re-insert kept rows from temp tables
 
+## Resume
+
+`main.rs` consumes `PipelineState` (`src/state.rs`). Each database-mutating step (Schema, Import, Filter, Indexes, Analyze) is wrapped by a `run_step` helper that checks `state.is_complete(...)` before running and persists the state file (default `./state`, override with `--state-file`) immediately on success. The Download step is not part of the state machine -- it has its own `--skip-download` flag and is naturally idempotent.
+
+CLI contract:
+
+- `--resume` + state file present: load and skip completed steps.
+- `--resume` + no state file: warn and start fresh.
+- no `--resume` + state file present: refuse with an error (avoids clobbering prior progress).
+- no `--resume` + no state file: fresh run; state file created during execution.
+
+With `--no-filter`, the Filter step is recorded as complete without running so a subsequent `--resume` can advance past it.
+
 ## Testing
 
 ```bash
@@ -71,4 +84,5 @@ TEST_DATABASE_URL=postgresql://musicbrainz:musicbrainz@localhost:5434/postgres \
 - **Unit tests** (22): TableSpec validation, column mapping, dependency ordering, normalization parity, library loading, download constants, tar.bz2 extraction, pipeline state persistence.
 - **Parity tests** (12): Import row counts vs baselines, sample data verification, NULL handling, alias/tag/recording data, filtered row counts, filtered artist sets, orphan detection. Gated on `TEST_DATABASE_URL`.
 - **State tests** (10): State file creation, step tracking, roundtrip serialization, resume skip logic, partial failure + resume, state clear.
+- **Resume integration tests** (4): End-to-end subprocess of the binary with `--resume`. Cover full-state skip, partial-state resume (skip Schema+Import, run Filter+Indexes+Analyze), refusal when state exists without `--resume`, and warn-and-start-fresh when `--resume` is passed with no state file. Gated on `TEST_DATABASE_URL`.
 - **Integration tests** (12): Full import, NULL handling, column extraction, artist matching, pruning, orphan cleanup. Require PostgreSQL on port 5434.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +186,12 @@ dependencies = [
  "cpufeatures",
  "rand_core",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
@@ -682,6 +694,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1089,7 @@ dependencies = [
  "rusqlite",
  "tar",
  "tempfile",
+ "tiny_http",
  "wxyc-etl",
 ]
 
@@ -1797,6 +1816,18 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,24 @@ Options:
     --skip-download                Skip download, use existing files
     --no-filter                    Import all artists without filtering
     --dump-url <DUMP_URL>          Override dump URL (default: auto-detect latest)
+    --resume                       Resume from a prior interrupted run by reading the state file
+    --state-file <STATE_FILE>      Path to the pipeline state file [default: ./state]
 ```
+
+## Resume
+
+The pipeline persists per-step completion to a state file (`--state-file`, default `./state`) after each successful step. To recover from a crashed or interrupted run, re-invoke the binary with `--resume`: previously-completed steps log a "Skipping ..." message and are not re-executed; the run picks up at the first incomplete step and continues to completion.
+
+State semantics:
+
+| `--resume` | state file exists | Behavior |
+|---|---|---|
+| no  | no  | Fresh run; state file is created during the run. |
+| no  | yes | Refused with an error. Pass `--resume` to continue, or remove the file to start fresh. This avoids accidentally clobbering a prior run's progress. |
+| yes | no  | Logs a warning and starts fresh; state file is created during the run. |
+| yes | yes | Loads completed steps and resumes; remaining steps execute and update the file. |
+
+Only the database-mutating steps (Schema, Import, Filter, Indexes, Analyze) participate in resume. The Download step is governed separately by `--skip-download` and is naturally idempotent (existing archives are reused). With `--no-filter`, the Filter step is recorded as complete without running so subsequent steps can advance during a later resume.
 
 ## Pipeline Steps
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use anyhow::{bail, Context};
 use clap::Parser;
+use musicbrainz_cache::state::{PipelineState, Step};
 use musicbrainz_cache::{download, filter, import, schema};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// MusicBrainz cache pipeline for WXYC.
 ///
@@ -36,6 +37,17 @@ struct Cli {
     /// Override dump URL (default: auto-detect latest).
     #[arg(long)]
     dump_url: Option<String>,
+
+    /// Resume an interrupted run by reading the state file and skipping
+    /// already-completed steps. If the state file does not exist, a fresh
+    /// run is performed (with a warning).
+    #[arg(long)]
+    resume: bool,
+
+    /// Path to the pipeline state file. Created during the run; consulted
+    /// on subsequent invocations when --resume is passed.
+    #[arg(long, default_value = "./state")]
+    state_file: PathBuf,
 }
 
 fn default_database_url() -> String {
@@ -57,6 +69,64 @@ fn wait_for_postgres(db_url: &str, timeout_secs: u64) -> anyhow::Result<()> {
     }
 }
 
+/// Initialize pipeline state from CLI flags.
+///
+/// - `--resume` with an existing state file: load it.
+/// - `--resume` with no state file: warn and start fresh.
+/// - No `--resume` with an existing state file: bail (refuse to clobber a
+///   prior run's state without an explicit opt-in).
+/// - No `--resume` with no state file: start fresh.
+fn init_state(state_path: &Path, resume: bool) -> anyhow::Result<PipelineState> {
+    let exists = state_path.exists();
+    match (resume, exists) {
+        (true, true) => {
+            let state = PipelineState::load(state_path)
+                .with_context(|| format!("Failed to load state file: {}", state_path.display()))?;
+            log::info!("Resuming from state file: {}", state_path.display());
+            Ok(state)
+        }
+        (true, false) => {
+            log::warn!(
+                "--resume passed but state file {} does not exist; starting fresh",
+                state_path.display()
+            );
+            Ok(PipelineState::new())
+        }
+        (false, true) => {
+            bail!(
+                "State file {} already exists from a prior run. Pass --resume to continue, \
+                 or remove the file to start fresh.",
+                state_path.display()
+            );
+        }
+        (false, false) => Ok(PipelineState::new()),
+    }
+}
+
+/// Run a step if it isn't already marked complete; persist state on success.
+fn run_step<F>(
+    state: &mut PipelineState,
+    state_path: &Path,
+    step: Step,
+    label: &str,
+    f: F,
+) -> anyhow::Result<()>
+where
+    F: FnOnce() -> anyhow::Result<()>,
+{
+    if state.is_complete(step) {
+        log::info!("Skipping {} (already complete)", label);
+        return Ok(());
+    }
+    log::info!("=== {} ===", label);
+    f()?;
+    state.mark_complete(step);
+    state
+        .save(state_path)
+        .with_context(|| format!("Failed to persist state file: {}", state_path.display()))?;
+    Ok(())
+}
+
 fn main() -> anyhow::Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -67,6 +137,8 @@ fn main() -> anyhow::Result<()> {
         bail!("--library-db required unless --no-filter is set");
     }
 
+    let mut state = init_state(&cli.state_file, cli.resume)?;
+
     let db_display = if let Some(idx) = cli.database_url.find('@') {
         &cli.database_url[idx + 1..]
     } else {
@@ -75,6 +147,7 @@ fn main() -> anyhow::Result<()> {
     log::info!("MusicBrainz cache pipeline starting");
     log::info!("  Data dir: {}", cli.data_dir.display());
     log::info!("  Database: {}", db_display);
+    log::info!("  State file: {}", cli.state_file.display());
     log::info!(
         "  Filter: {}",
         if cli.no_filter {
@@ -87,7 +160,9 @@ fn main() -> anyhow::Result<()> {
         }
     );
 
-    // Step 1: Download and extract
+    // Download is intentionally not part of `PipelineState` -- it has its own
+    // `--skip-download` flag and is naturally idempotent (existing archives
+    // are reused). The resumable steps are the database-mutating ones below.
     if !cli.skip_download {
         let dump_url = match &cli.dump_url {
             Some(url) => url.clone(),
@@ -119,35 +194,68 @@ fn main() -> anyhow::Result<()> {
         bail!("mbdump directory not found: {}", mbdump_dir.display());
     }
 
-    // Step 2: Wait for PostgreSQL
+    // Wait for PostgreSQL and establish a single client used by every
+    // resumable step.
     wait_for_postgres(&cli.database_url, 30)?;
-
-    // Step 3: Apply schema
     let mut client = postgres::Client::connect(&cli.database_url, postgres::NoTls)
         .context("Failed to connect to PostgreSQL")?;
-    schema::apply_schema(&mut client)?;
 
-    // Step 4: Import TSV files
-    log::info!("=== Import TSV files ===");
-    import::import_all(&mut client, &mbdump_dir)?;
+    run_step(
+        &mut state,
+        &cli.state_file,
+        Step::Schema,
+        "Apply schema",
+        || schema::apply_schema(&mut client),
+    )?;
 
-    // Step 5: Filter to WXYC artists
+    run_step(
+        &mut state,
+        &cli.state_file,
+        Step::Import,
+        "Import TSV files",
+        || import::import_all(&mut client, &mbdump_dir).map(|_| ()),
+    )?;
+
     if !cli.no_filter {
-        let library_db = cli.library_db.as_ref().unwrap();
-        log::info!("=== Filter to WXYC library artists ===");
-        let library_artists = filter::load_library_artists(library_db)?;
-        let matching = filter::find_matching_artist_ids(&mut client, &library_artists)?;
-        filter::prune_to_matching(&mut client, &matching)?;
-        filter::report_sizes(&mut client)?;
+        let library_db = cli.library_db.as_ref().unwrap().clone();
+        run_step(
+            &mut state,
+            &cli.state_file,
+            Step::Filter,
+            "Filter to WXYC library artists",
+            || {
+                let library_artists = filter::load_library_artists(&library_db)?;
+                let matching = filter::find_matching_artist_ids(&mut client, &library_artists)?;
+                filter::prune_to_matching(&mut client, &matching)?;
+                filter::report_sizes(&mut client)?;
+                Ok(())
+            },
+        )?;
+    } else if !state.is_complete(Step::Filter) {
+        // With --no-filter we never run the Filter step, but for resume
+        // accounting we still mark it complete so subsequent steps advance.
+        state.mark_complete(Step::Filter);
+        state.save(&cli.state_file).with_context(|| {
+            format!("Failed to persist state file: {}", cli.state_file.display())
+        })?;
+        log::info!("Skipping Filter (--no-filter set)");
     }
 
-    // Step 6: Create indexes
-    log::info!("=== Create indexes ===");
-    schema::create_indexes(&mut client)?;
+    run_step(
+        &mut state,
+        &cli.state_file,
+        Step::Indexes,
+        "Create indexes",
+        || schema::create_indexes(&mut client),
+    )?;
 
-    // Step 7: Analyze
-    log::info!("=== Analyze ===");
-    schema::analyze_tables(&mut client)?;
+    run_step(
+        &mut state,
+        &cli.state_file,
+        Step::Analyze,
+        "Analyze",
+        || schema::analyze_tables(&mut client),
+    )?;
 
     let elapsed = pipeline_start.elapsed();
     log::info!("Pipeline complete in {:.1}s", elapsed.as_secs_f64());

--- a/tests/resume_integration_test.rs
+++ b/tests/resume_integration_test.rs
@@ -1,136 +1,218 @@
-//! Orchestrator-level resume integration test.
+//! End-to-end resume integration test for the `musicbrainz-cache` binary.
 //!
-//! Drives the pipeline functions in the same order `main.rs` does (schema ->
-//! import -> filter -> indexes -> analyze) while persisting `PipelineState`
-//! between phases. Verifies that after a partial run the saved state file
-//! reflects only the completed steps, and that a subsequent resume completes
-//! the remaining steps without re-running the earlier ones.
+//! Subprocesses the binary with `--resume` and a pre-populated state file,
+//! verifies that completed steps are skipped (per stderr logs) and that the
+//! remaining steps run and update the state file.
 //!
-//! Gated on TEST_DATABASE_URL: returns early when unset (matches the pattern
+//! Gated on `TEST_DATABASE_URL`: returns early when unset (matches the pattern
 //! used in `parity_test.rs`).
 
 use musicbrainz_cache::state::{PipelineState, Step};
 use std::path::PathBuf;
+use std::process::Command;
 
 fn test_db_url() -> Option<String> {
     std::env::var("TEST_DATABASE_URL").ok()
 }
 
-fn fixtures_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mbdump")
+fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
 }
 
 fn library_db_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/library.db")
+    fixtures_root().join("library.db")
 }
 
-/// Run a single pipeline step, marking it complete in state and persisting on success.
-/// Mirrors the orchestration loop a state-aware `main.rs` would use.
-fn run_step<F>(
-    state: &mut PipelineState,
-    state_path: &std::path::Path,
-    step: Step,
-    f: F,
-) -> anyhow::Result<bool>
-where
-    F: FnOnce() -> anyhow::Result<()>,
-{
-    if state.is_complete(step) {
-        return Ok(false);
+/// Path to the compiled binary for this crate. Cargo provides this env var
+/// to integration tests automatically.
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_musicbrainz-cache")
+}
+
+/// Drop every `mb_*` table so each invocation starts from a known state.
+fn reset_database(db_url: &str) {
+    let mut client =
+        postgres::Client::connect(db_url, postgres::NoTls).expect("connect to test database");
+    let rows = client
+        .query(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE 'mb_%'",
+            &[],
+        )
+        .unwrap();
+    for row in rows {
+        let table: String = row.get(0);
+        client
+            .batch_execute(&format!("DROP TABLE IF EXISTS {} CASCADE", table))
+            .unwrap();
     }
-    f()?;
-    state.mark_complete(step);
-    state.save(state_path)?;
-    Ok(true)
+}
+
+/// Drop every `idx_mb_*` index. Used to simulate a crash that occurred
+/// before the Indexes step ran.
+fn drop_mb_indexes(db_url: &str) {
+    let mut client =
+        postgres::Client::connect(db_url, postgres::NoTls).expect("connect to test database");
+    let rows = client
+        .query(
+            "SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND indexname LIKE 'idx_mb_%'",
+            &[],
+        )
+        .unwrap();
+    for row in rows {
+        let idx: String = row.get(0);
+        client
+            .batch_execute(&format!("DROP INDEX IF EXISTS {}", idx))
+            .unwrap();
+    }
+}
+
+/// Run the binary with the supplied args plus the standard fixture flags.
+fn run_binary(args: &[&str], db_url: &str) -> std::process::Output {
+    Command::new(binary_path())
+        .arg("--data-dir")
+        .arg(fixtures_root())
+        .arg("--library-db")
+        .arg(library_db_path())
+        .arg("--database-url")
+        .arg(db_url)
+        .arg("--skip-download")
+        .args(args)
+        .env("RUST_LOG", "info")
+        .output()
+        .expect("spawn binary")
 }
 
 #[test]
 #[ignore] // Requires PostgreSQL: TEST_DATABASE_URL=... cargo test --test resume_integration_test -- --ignored
-fn test_pipeline_resume_skips_completed_steps() {
+fn test_full_resume_skips_every_step() {
     let Some(db_url) = test_db_url() else { return };
+
+    reset_database(&db_url);
 
     let tmp = tempfile::tempdir().unwrap();
     let state_path = tmp.path().join("pipeline.state");
 
-    // ----- First run: complete only schema + import, then "interrupt". -----
-    {
-        let mut state = PipelineState::load(&state_path).unwrap();
-        let mut client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
-
-        let schema_ran = run_step(&mut state, &state_path, Step::Schema, || {
-            musicbrainz_cache::schema::apply_schema(&mut client)
-        })
-        .unwrap();
-        assert!(schema_ran, "Schema should run on first invocation");
-
-        let import_ran = run_step(&mut state, &state_path, Step::Import, || {
-            musicbrainz_cache::import::import_all(&mut client, &fixtures_dir()).map(|_| ())
-        })
-        .unwrap();
-        assert!(import_ran, "Import should run on first invocation");
-
-        // Simulated interruption before filter/indexes/analyze.
-    }
-
-    // The state file persists exactly the two completed steps.
-    {
-        let state = PipelineState::load(&state_path).unwrap();
-        assert!(state.is_complete(Step::Schema));
-        assert!(state.is_complete(Step::Import));
-        assert!(!state.is_complete(Step::Filter));
-        assert!(!state.is_complete(Step::Indexes));
-        assert!(!state.is_complete(Step::Analyze));
-    }
-
-    // ----- Second run (resume): only the remaining steps execute. -----
-    let (schema_ran_again, import_ran_again, filter_ran, indexes_ran, analyze_ran);
-    {
-        let mut state = PipelineState::load(&state_path).unwrap();
-        let mut client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
-
-        schema_ran_again = run_step(&mut state, &state_path, Step::Schema, || {
-            musicbrainz_cache::schema::apply_schema(&mut client)
-        })
-        .unwrap();
-
-        import_ran_again = run_step(&mut state, &state_path, Step::Import, || {
-            musicbrainz_cache::import::import_all(&mut client, &fixtures_dir()).map(|_| ())
-        })
-        .unwrap();
-
-        filter_ran = run_step(&mut state, &state_path, Step::Filter, || {
-            let library_artists =
-                musicbrainz_cache::filter::load_library_artists(&library_db_path())?;
-            let matching =
-                musicbrainz_cache::filter::find_matching_artist_ids(&mut client, &library_artists)?;
-            musicbrainz_cache::filter::prune_to_matching(&mut client, &matching)
-        })
-        .unwrap();
-
-        indexes_ran = run_step(&mut state, &state_path, Step::Indexes, || {
-            musicbrainz_cache::schema::create_indexes(&mut client)
-        })
-        .unwrap();
-
-        analyze_ran = run_step(&mut state, &state_path, Step::Analyze, || {
-            musicbrainz_cache::schema::analyze_tables(&mut client)
-        })
-        .unwrap();
-    }
-
+    // First run: full pipeline against an empty DB.
+    let out = run_binary(&["--state-file", state_path.to_str().unwrap()], &db_url);
     assert!(
-        !schema_ran_again,
-        "Schema must be skipped on resume (was already complete)"
+        out.status.success(),
+        "fresh run failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let state = PipelineState::load(&state_path).unwrap();
+    for step in [
+        Step::Schema,
+        Step::Import,
+        Step::Filter,
+        Step::Indexes,
+        Step::Analyze,
+    ] {
+        assert!(
+            state.is_complete(step),
+            "fresh run should mark {:?} complete",
+            step
+        );
+    }
+
+    // Second run with --resume against the fully-complete state: every step
+    // should log a skip message.
+    let out = run_binary(
+        &["--resume", "--state-file", state_path.to_str().unwrap()],
+        &db_url,
     );
     assert!(
-        !import_ran_again,
-        "Import must be skipped on resume (was already complete)"
+        out.status.success(),
+        "resume run failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
     );
-    assert!(filter_ran, "Filter should run on resume");
-    assert!(indexes_ran, "Indexes should run on resume");
-    assert!(analyze_ran, "Analyze should run on resume");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    for label in [
+        "Skipping Apply schema",
+        "Skipping Import TSV files",
+        "Skipping Filter to WXYC library artists",
+        "Skipping Create indexes",
+        "Skipping Analyze",
+    ] {
+        assert!(
+            stderr.contains(label),
+            "expected log {:?} on full-resume run.\nstderr was:\n{}",
+            label,
+            stderr,
+        );
+    }
+}
 
-    // Final state has every step recorded as complete.
+#[test]
+#[ignore] // Requires PostgreSQL: TEST_DATABASE_URL=... cargo test --test resume_integration_test -- --ignored
+fn test_partial_state_resume_runs_remaining_steps() {
+    let Some(db_url) = test_db_url() else { return };
+
+    reset_database(&db_url);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let state_path = tmp.path().join("pipeline.state");
+
+    // Seed the database via a normal pipeline run, then rewrite the state
+    // file to mark only Schema + Import complete -- as if the run had
+    // crashed between Import and Filter.
+    let fresh = run_binary(&["--state-file", state_path.to_str().unwrap()], &db_url);
+    assert!(
+        fresh.status.success(),
+        "fresh seed run failed.\nstderr: {}",
+        String::from_utf8_lossy(&fresh.stderr),
+    );
+
+    let mut state = PipelineState::new();
+    state.mark_complete(Step::Schema);
+    state.mark_complete(Step::Import);
+    state.save(&state_path).unwrap();
+
+    // The seed run already created the secondary indexes; drop them so the
+    // resume's Indexes step can recreate them without "already exists" errors.
+    // (`schema::create_indexes` does not use IF NOT EXISTS by design.)
+    drop_mb_indexes(&db_url);
+
+    // Resume: Schema + Import skipped, Filter/Indexes/Analyze run.
+    let out = run_binary(
+        &["--resume", "--state-file", state_path.to_str().unwrap()],
+        &db_url,
+    );
+    assert!(
+        out.status.success(),
+        "resume run failed.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        stderr.contains("Skipping Apply schema"),
+        "expected Schema to be skipped.\nstderr:\n{}",
+        stderr,
+    );
+    assert!(
+        stderr.contains("Skipping Import TSV files"),
+        "expected Import to be skipped.\nstderr:\n{}",
+        stderr,
+    );
+    assert!(
+        stderr.contains("=== Filter to WXYC library artists ==="),
+        "expected Filter to run.\nstderr:\n{}",
+        stderr,
+    );
+    assert!(
+        stderr.contains("=== Create indexes ==="),
+        "expected Indexes to run.\nstderr:\n{}",
+        stderr,
+    );
+    assert!(
+        stderr.contains("=== Analyze ==="),
+        "expected Analyze to run.\nstderr:\n{}",
+        stderr,
+    );
+
     let final_state = PipelineState::load(&state_path).unwrap();
     for step in [
         Step::Schema,
@@ -146,9 +228,8 @@ fn test_pipeline_resume_skips_completed_steps() {
         );
     }
 
-    // Sanity-check that the filter step actually ran against real data:
-    // only the WXYC library artists (Autechre, Stereolab, Jessica Pratt)
-    // should remain after filtering.
+    // Filter actually ran against real data: only the WXYC library artists
+    // (Autechre, Stereolab, Jessica Pratt) should remain.
     let mut client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
     let rows = client
         .query("SELECT name FROM mb_artist ORDER BY name", &[])
@@ -161,6 +242,77 @@ fn test_pipeline_resume_skips_completed_steps() {
             "Jessica Pratt".to_string(),
             "Stereolab".to_string(),
         ],
-        "Filter step should have pruned to library artists"
+        "Filter step should have pruned to library artists",
     );
+}
+
+#[test]
+#[ignore] // Requires PostgreSQL: TEST_DATABASE_URL=... cargo test --test resume_integration_test -- --ignored
+fn test_existing_state_without_resume_is_refused() {
+    let Some(db_url) = test_db_url() else { return };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let state_path = tmp.path().join("pipeline.state");
+
+    // Leftover state from a "previous" run.
+    let mut state = PipelineState::new();
+    state.mark_complete(Step::Schema);
+    state.save(&state_path).unwrap();
+
+    let out = run_binary(&["--state-file", state_path.to_str().unwrap()], &db_url);
+    assert!(
+        !out.status.success(),
+        "binary should bail when state file exists without --resume.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("already exists") && stderr.contains("--resume"),
+        "expected refusal message mentioning --resume.\nstderr:\n{}",
+        stderr,
+    );
+}
+
+#[test]
+#[ignore] // Requires PostgreSQL: TEST_DATABASE_URL=... cargo test --test resume_integration_test -- --ignored
+fn test_resume_with_missing_state_file_starts_fresh() {
+    let Some(db_url) = test_db_url() else { return };
+
+    reset_database(&db_url);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let state_path = tmp.path().join("pipeline.state");
+    assert!(!state_path.exists());
+
+    let out = run_binary(
+        &["--resume", "--state-file", state_path.to_str().unwrap()],
+        &db_url,
+    );
+    assert!(
+        out.status.success(),
+        "resume-with-missing-state run failed.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("does not exist") && stderr.contains("starting fresh"),
+        "expected warning about missing state file.\nstderr:\n{}",
+        stderr,
+    );
+
+    let final_state = PipelineState::load(&state_path).unwrap();
+    for step in [
+        Step::Schema,
+        Step::Import,
+        Step::Filter,
+        Step::Indexes,
+        Step::Analyze,
+    ] {
+        assert!(
+            final_state.is_complete(step),
+            "Step {:?} should be complete after fresh resume",
+            step
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Refactor `src/main.rs` to wrap each database-mutating step (Schema, Import, Filter, Indexes, Analyze) with a `run_step` helper that checks `PipelineState::is_complete` and persists the state file immediately on success.
- Add `--resume` and `--state-file` CLI flags (default state file: `./state`). Download remains outside the state machine -- it has `--skip-download` and is naturally idempotent.
- Replace `tests/resume_integration_test.rs` with four end-to-end subprocess tests against the compiled binary, addressing the gap noted by #14.
- Document the resume contract in README and CLAUDE.md.

State semantics:

| `--resume` | state file exists | Behavior |
|---|---|---|
| no  | no  | Fresh run; state file created during execution. |
| no  | yes | Refused with a clear error so in-progress state cannot be silently clobbered. |
| yes | no  | Warn and start fresh. |
| yes | yes | Load completed steps and resume. |

With `--no-filter`, the Filter step is recorded as complete without running so a subsequent `--resume` advances past it.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --tests -- -D warnings -A clippy::manual_is_multiple_of`
- [x] `cargo build --tests`
- [x] `cargo test --lib --bins` (state unit tests)
- [x] `cargo test --test state_test` (10 state tests)
- [x] `TEST_DATABASE_URL=... cargo test --test resume_integration_test -- --ignored --test-threads=1` -- 4 tests pass: full-resume skip, partial-state resume (asserts filter pruned to Autechre/Stereolab/Jessica Pratt), refusal without --resume, warn-and-fresh on missing state file.

Closes #15