### PR TITLE
Make every pipeline step idempotent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,23 @@ CLI contract:
 
 With `--no-filter`, the Filter step is recorded as complete without running so a subsequent `--resume` can advance past it.
 
+## Resume safety
+
+`--resume` is only safe when two invariants hold:
+
+1. **commit-before-save**: `state.save()` MUST run AFTER the step's PG work has committed. The `run_step` helper in `main.rs` enforces this -- it calls `f()` (which uses `postgres::Client` autocommit, so each `batch_execute`/`copy_in` commits before returning) and only then calls `state.mark_complete(...)` followed by `state.save(...)`. If the order were inverted, a crash mid-commit could leave the state file ahead of the database, causing the step to be skipped on resume despite incomplete data.
+2. **idempotent steps**: every step's SQL must be safe to run twice in a row without changing observable state. A crash between PG commit and `state.save()` will cause that step to re-execute on the next `--resume`; if the step is not idempotent, that re-execution would either fail or duplicate data.
+
+How each step satisfies idempotency:
+
+- **Schema** (`schema/create_database.sql`): every statement uses `CREATE EXTENSION IF NOT EXISTS` / `CREATE TABLE IF NOT EXISTS`. Re-applying against a populated database is a no-op and does NOT drop existing data. Tests that need a clean slate must call `schema::drop_all_tables` first.
+- **Import** (`src/import.rs`): `import_table` checks `SELECT COUNT(*)` on the destination table and skips the COPY when rows are already present. This avoids the PRIMARY-KEY UniqueViolation that re-COPYing would trip and prevents duplicates on tables without a PK.
+- **Filter** (`src/filter.rs`): copy-and-swap is naturally idempotent. On re-run the matching artist set is identical (same library.db, same artist names), the same rows are saved to temp tables, the originals are TRUNCATE'd, and the same rows are re-inserted. Net change: zero rows.
+- **Indexes** (`schema/create_indexes.sql`): every `CREATE INDEX` uses `IF NOT EXISTS`, so re-running on an already-indexed database is a no-op.
+- **Analyze** (`src/schema.rs::analyze_tables`): `ANALYZE` is inherently idempotent.
+
+The `tests/idempotency_test.rs` integration test exercises every step twice in a row against a fixture database and asserts that row counts and the index set are unchanged on the second invocation. It is the safety net that catches regressions in any of the rules above.
+
 ## Testing
 
 ```bash
@@ -85,4 +102,5 @@ TEST_DATABASE_URL=postgresql://musicbrainz:musicbrainz@localhost:5434/postgres \
 - **Parity tests** (12): Import row counts vs baselines, sample data verification, NULL handling, alias/tag/recording data, filtered row counts, filtered artist sets, orphan detection. Gated on `TEST_DATABASE_URL`.
 - **State tests** (10): State file creation, step tracking, roundtrip serialization, resume skip logic, partial failure + resume, state clear.
 - **Resume integration tests** (4): End-to-end subprocess of the binary with `--resume`. Cover full-state skip, partial-state resume (skip Schema+Import, run Filter+Indexes+Analyze), refusal when state exists without `--resume`, and warn-and-start-fresh when `--resume` is passed with no state file. Gated on `TEST_DATABASE_URL`.
+- **Idempotency test** (1): Runs each pipeline step twice in a row and asserts row counts and the index set are unchanged on the second invocation. Enforces the "Resume safety" invariants. Gated on `TEST_DATABASE_URL`.
 - **Integration tests** (12): Full import, NULL handling, column extraction, artist matching, pruning, orphan cleanup. Require PostgreSQL on port 5434.

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -1,62 +1,45 @@
 -- MusicBrainz cache schema for WXYC genre/area analysis.
 -- Imports a subset of MusicBrainz tables relevant to artist classification.
 -- Table prefix mb_ to avoid conflicts when sharing a PostgreSQL instance.
+--
+-- Idempotency: every statement is re-runnable. Re-applying the schema against
+-- a populated database is a no-op and does NOT drop existing data. This is a
+-- requirement of the `--resume` flow (see CLAUDE.md "Resume safety"). Tests:
+-- tests/idempotency_test.rs.
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 CREATE EXTENSION IF NOT EXISTS unaccent;
 
--- Drop in FK-safe order (children first)
-DROP TABLE IF EXISTS mb_l_release_url CASCADE;
-DROP TABLE IF EXISTS mb_l_release_group_url CASCADE;
-DROP TABLE IF EXISTS mb_release CASCADE;
-DROP TABLE IF EXISTS mb_link CASCADE;
-DROP TABLE IF EXISTS mb_link_type CASCADE;
-DROP TABLE IF EXISTS mb_url CASCADE;
-DROP TABLE IF EXISTS mb_track CASCADE;
-DROP TABLE IF EXISTS mb_medium CASCADE;
-DROP TABLE IF EXISTS mb_recording CASCADE;
-DROP TABLE IF EXISTS mb_artist_tag CASCADE;
-DROP TABLE IF EXISTS mb_artist_credit_name CASCADE;
-DROP TABLE IF EXISTS mb_release_group CASCADE;
-DROP TABLE IF EXISTS mb_artist_credit CASCADE;
-DROP TABLE IF EXISTS mb_artist_alias CASCADE;
-DROP TABLE IF EXISTS mb_artist CASCADE;
-DROP TABLE IF EXISTS mb_country_area CASCADE;
-DROP TABLE IF EXISTS mb_area CASCADE;
-DROP TABLE IF EXISTS mb_area_type CASCADE;
-DROP TABLE IF EXISTS mb_gender CASCADE;
-DROP TABLE IF EXISTS mb_tag CASCADE;
-
 -- Reference tables
 
-CREATE TABLE mb_area_type (
+CREATE TABLE IF NOT EXISTS mb_area_type (
     id          integer PRIMARY KEY,
     name        text NOT NULL
 );
 
-CREATE TABLE mb_gender (
+CREATE TABLE IF NOT EXISTS mb_gender (
     id          integer PRIMARY KEY,
     name        text NOT NULL
 );
 
-CREATE TABLE mb_tag (
+CREATE TABLE IF NOT EXISTS mb_tag (
     id          integer PRIMARY KEY,
     name        text NOT NULL
 );
 
-CREATE TABLE mb_area (
+CREATE TABLE IF NOT EXISTS mb_area (
     id          integer PRIMARY KEY,
     name        text NOT NULL,
     type        integer REFERENCES mb_area_type(id)
 );
 
-CREATE TABLE mb_country_area (
+CREATE TABLE IF NOT EXISTS mb_country_area (
     area        integer PRIMARY KEY REFERENCES mb_area(id)
 );
 
 -- Core artist tables
 
-CREATE TABLE mb_artist (
+CREATE TABLE IF NOT EXISTS mb_artist (
     id          integer PRIMARY KEY,
     name        text NOT NULL,
     sort_name   text NOT NULL,
@@ -67,7 +50,7 @@ CREATE TABLE mb_artist (
     comment     text NOT NULL DEFAULT ''
 );
 
-CREATE TABLE mb_artist_alias (
+CREATE TABLE IF NOT EXISTS mb_artist_alias (
     id          integer PRIMARY KEY,
     artist      integer NOT NULL REFERENCES mb_artist(id) ON DELETE CASCADE,
     name        text NOT NULL,
@@ -77,7 +60,7 @@ CREATE TABLE mb_artist_alias (
     primary_for_locale boolean NOT NULL DEFAULT false
 );
 
-CREATE TABLE mb_artist_tag (
+CREATE TABLE IF NOT EXISTS mb_artist_tag (
     artist      integer NOT NULL REFERENCES mb_artist(id) ON DELETE CASCADE,
     tag         integer NOT NULL REFERENCES mb_tag(id),
     count       integer NOT NULL,
@@ -86,13 +69,13 @@ CREATE TABLE mb_artist_tag (
 
 -- Release matching tables
 
-CREATE TABLE mb_artist_credit (
+CREATE TABLE IF NOT EXISTS mb_artist_credit (
     id          integer PRIMARY KEY,
     name        text NOT NULL,
     artist_count smallint NOT NULL
 );
 
-CREATE TABLE mb_artist_credit_name (
+CREATE TABLE IF NOT EXISTS mb_artist_credit_name (
     artist_credit integer NOT NULL REFERENCES mb_artist_credit(id) ON DELETE CASCADE,
     position    smallint NOT NULL,
     artist      integer NOT NULL REFERENCES mb_artist(id) ON DELETE CASCADE,
@@ -100,7 +83,7 @@ CREATE TABLE mb_artist_credit_name (
     join_phrase text NOT NULL DEFAULT ''
 );
 
-CREATE TABLE mb_release_group (
+CREATE TABLE IF NOT EXISTS mb_release_group (
     id          integer PRIMARY KEY,
     name        text NOT NULL,
     artist_credit integer NOT NULL REFERENCES mb_artist_credit(id),
@@ -109,7 +92,7 @@ CREATE TABLE mb_release_group (
 
 -- Recording tables (for AcousticBrainz feature lookup)
 
-CREATE TABLE mb_recording (
+CREATE TABLE IF NOT EXISTS mb_recording (
     id          integer PRIMARY KEY,
     gid         uuid NOT NULL,          -- MusicBrainz recording MBID
     name        text NOT NULL,
@@ -117,14 +100,14 @@ CREATE TABLE mb_recording (
     length      integer                  -- milliseconds
 );
 
-CREATE TABLE mb_medium (
+CREATE TABLE IF NOT EXISTS mb_medium (
     id          integer PRIMARY KEY,
     release     integer,
     position    integer,
     format      integer
 );
 
-CREATE TABLE mb_track (
+CREATE TABLE IF NOT EXISTS mb_track (
     id          integer PRIMARY KEY,
     recording   integer NOT NULL REFERENCES mb_recording(id),
     medium      integer NOT NULL REFERENCES mb_medium(id),
@@ -136,25 +119,25 @@ CREATE TABLE mb_track (
 
 -- URL/streaming tables
 
-CREATE TABLE mb_url (
+CREATE TABLE IF NOT EXISTS mb_url (
     id          integer PRIMARY KEY,
     gid         uuid NOT NULL,
     url         text NOT NULL
 );
 
-CREATE TABLE mb_link_type (
+CREATE TABLE IF NOT EXISTS mb_link_type (
     id          integer PRIMARY KEY,
     name        text NOT NULL,
     entity_type0 text NOT NULL,
     entity_type1 text NOT NULL
 );
 
-CREATE TABLE mb_link (
+CREATE TABLE IF NOT EXISTS mb_link (
     id          integer PRIMARY KEY,
     link_type   integer NOT NULL REFERENCES mb_link_type(id)
 );
 
-CREATE TABLE mb_release (
+CREATE TABLE IF NOT EXISTS mb_release (
     id              integer PRIMARY KEY,
     gid             uuid NOT NULL,
     name            text NOT NULL,
@@ -162,14 +145,14 @@ CREATE TABLE mb_release (
     release_group   integer NOT NULL REFERENCES mb_release_group(id)
 );
 
-CREATE TABLE mb_l_release_group_url (
+CREATE TABLE IF NOT EXISTS mb_l_release_group_url (
     id          integer PRIMARY KEY,
     link        integer NOT NULL REFERENCES mb_link(id),
     release_group integer NOT NULL REFERENCES mb_release_group(id),
     url         integer NOT NULL REFERENCES mb_url(id)
 );
 
-CREATE TABLE mb_l_release_url (
+CREATE TABLE IF NOT EXISTS mb_l_release_url (
     id          integer PRIMARY KEY,
     link        integer NOT NULL REFERENCES mb_link(id),
     release     integer NOT NULL REFERENCES mb_release(id),

--- a/schema/create_indexes.sql
+++ b/schema/create_indexes.sql
@@ -1,26 +1,29 @@
 -- Secondary indexes for MusicBrainz cache tables.
 -- Applied after bulk import and filtering for faster pipeline throughput.
+--
+-- Idempotency: every CREATE INDEX uses IF NOT EXISTS so the Indexes step
+-- can be re-run safely under `--resume` (see CLAUDE.md "Resume safety").
 
-CREATE INDEX idx_mb_recording_gid ON mb_recording(gid);
-CREATE INDEX idx_mb_recording_credit ON mb_recording(artist_credit);
-CREATE INDEX idx_mb_track_recording ON mb_track(recording);
-CREATE INDEX idx_mb_track_medium ON mb_track(medium);
-CREATE INDEX idx_mb_artist_name_lower ON mb_artist (lower(name));
-CREATE INDEX idx_mb_artist_area ON mb_artist (area);
-CREATE INDEX idx_mb_artist_alias_artist ON mb_artist_alias (artist);
-CREATE INDEX idx_mb_artist_alias_name_lower ON mb_artist_alias (lower(name));
-CREATE INDEX idx_mb_artist_tag_artist ON mb_artist_tag (artist);
-CREATE INDEX idx_mb_artist_tag_tag ON mb_artist_tag (tag);
-CREATE INDEX idx_mb_artist_credit_name_artist ON mb_artist_credit_name (artist);
-CREATE INDEX idx_mb_artist_credit_name_credit ON mb_artist_credit_name (artist_credit);
-CREATE INDEX idx_mb_release_group_credit ON mb_release_group (artist_credit);
-CREATE INDEX idx_mb_area_type ON mb_area (type);
-CREATE INDEX idx_mb_url_gid ON mb_url(gid);
-CREATE INDEX idx_mb_release_gid ON mb_release(gid);
-CREATE INDEX idx_mb_release_release_group ON mb_release(release_group);
-CREATE INDEX idx_mb_release_credit ON mb_release(artist_credit);
-CREATE INDEX idx_mb_l_release_group_url_rg ON mb_l_release_group_url(release_group);
-CREATE INDEX idx_mb_l_release_group_url_url ON mb_l_release_group_url(url);
-CREATE INDEX idx_mb_l_release_url_release ON mb_l_release_url(release);
-CREATE INDEX idx_mb_l_release_url_url ON mb_l_release_url(url);
-CREATE INDEX idx_mb_link_type ON mb_link(link_type);
+CREATE INDEX IF NOT EXISTS idx_mb_recording_gid ON mb_recording(gid);
+CREATE INDEX IF NOT EXISTS idx_mb_recording_credit ON mb_recording(artist_credit);
+CREATE INDEX IF NOT EXISTS idx_mb_track_recording ON mb_track(recording);
+CREATE INDEX IF NOT EXISTS idx_mb_track_medium ON mb_track(medium);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_name_lower ON mb_artist (lower(name));
+CREATE INDEX IF NOT EXISTS idx_mb_artist_area ON mb_artist (area);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_alias_artist ON mb_artist_alias (artist);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_alias_name_lower ON mb_artist_alias (lower(name));
+CREATE INDEX IF NOT EXISTS idx_mb_artist_tag_artist ON mb_artist_tag (artist);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_tag_tag ON mb_artist_tag (tag);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_credit_name_artist ON mb_artist_credit_name (artist);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_credit_name_credit ON mb_artist_credit_name (artist_credit);
+CREATE INDEX IF NOT EXISTS idx_mb_release_group_credit ON mb_release_group (artist_credit);
+CREATE INDEX IF NOT EXISTS idx_mb_area_type ON mb_area (type);
+CREATE INDEX IF NOT EXISTS idx_mb_url_gid ON mb_url(gid);
+CREATE INDEX IF NOT EXISTS idx_mb_release_gid ON mb_release(gid);
+CREATE INDEX IF NOT EXISTS idx_mb_release_release_group ON mb_release(release_group);
+CREATE INDEX IF NOT EXISTS idx_mb_release_credit ON mb_release(artist_credit);
+CREATE INDEX IF NOT EXISTS idx_mb_l_release_group_url_rg ON mb_l_release_group_url(release_group);
+CREATE INDEX IF NOT EXISTS idx_mb_l_release_group_url_url ON mb_l_release_group_url(url);
+CREATE INDEX IF NOT EXISTS idx_mb_l_release_url_release ON mb_l_release_url(release);
+CREATE INDEX IF NOT EXISTS idx_mb_l_release_url_url ON mb_l_release_url(url);
+CREATE INDEX IF NOT EXISTS idx_mb_link_type ON mb_link(link_type);

--- a/src/import.rs
+++ b/src/import.rs
@@ -137,6 +137,13 @@ pub static DERIVED_TABLES: &[&str] = &["artist_tag", "tag"];
 ///
 /// Reads the full-width TSV, extracts only the columns we need,
 /// and streams them to PostgreSQL via COPY.
+///
+/// Idempotent: if the destination table already has rows, this function
+/// logs a skip message and returns 0 without re-importing. This makes the
+/// Import step safe to re-run after a partial completion (e.g. when the
+/// pipeline crashed mid-Import and `--resume` re-invokes the step). The
+/// alternative -- COPYing into a populated table -- would either trip
+/// PRIMARY KEY UniqueViolations or duplicate rows on tables without a PK.
 pub fn import_table(
     client: &mut postgres::Client,
     spec: &TableSpec,
@@ -145,6 +152,19 @@ pub fn import_table(
     let tsv_path = data_dir.join(spec.dump_file);
     if !tsv_path.exists() {
         log::warn!("File not found, skipping: {}", tsv_path.display());
+        return Ok(0);
+    }
+
+    // Idempotency guard: skip tables that are already populated. See doc above.
+    let existing: i64 = client
+        .query_one(&format!("SELECT COUNT(*) FROM {}", spec.table), &[])?
+        .get(0);
+    if existing > 0 {
+        log::info!(
+            "  {}: {} rows already present, skipping import (idempotent)",
+            spec.table,
+            existing,
+        );
         return Ok(0);
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4,12 +4,38 @@ use std::path::Path;
 const SCHEMA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/schema");
 
 /// Apply the database schema from create_database.sql.
+///
+/// Idempotent: every statement uses `CREATE TABLE IF NOT EXISTS` /
+/// `CREATE EXTENSION IF NOT EXISTS`. Re-applying against a populated
+/// database is a no-op and does NOT drop existing data. This is required
+/// so that `--resume` can safely re-run the Schema step without erasing
+/// the work of the Import or Filter steps. To reset the database for
+/// tests or a clean rebuild, call [`drop_all_tables`] first.
 pub fn apply_schema(client: &mut postgres::Client) -> anyhow::Result<()> {
     let sql_path = Path::new(SCHEMA_DIR).join("create_database.sql");
     let sql = std::fs::read_to_string(&sql_path)
         .with_context(|| format!("Failed to read {}", sql_path.display()))?;
     client.batch_execute(&sql)?;
     log::info!("Schema applied.");
+    Ok(())
+}
+
+/// Drop every `mb_*` table in the public schema (CASCADE).
+///
+/// This is the destructive reset that used to live inside `apply_schema`.
+/// It is intentionally a separate function so production runs (especially
+/// `--resume`) never accidentally drop a populated database. Tests and
+/// "clean rebuild" workflows that want a blank slate should call this
+/// before [`apply_schema`].
+pub fn drop_all_tables(client: &mut postgres::Client) -> anyhow::Result<()> {
+    let rows = client.query(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE 'mb_%'",
+        &[],
+    )?;
+    for row in rows {
+        let table: String = row.get(0);
+        client.batch_execute(&format!("DROP TABLE IF EXISTS {table} CASCADE"))?;
+    }
     Ok(())
 }
 

--- a/tests/filter_test.rs
+++ b/tests/filter_test.rs
@@ -64,6 +64,8 @@ fn test_load_library_artists() {
 
 fn set_up_full_db() -> postgres::Client {
     let mut client = postgres::Client::connect(&db_url(), postgres::NoTls).unwrap();
+    // apply_schema is idempotent; drop first so import_all sees empty tables.
+    musicbrainz_cache::schema::drop_all_tables(&mut client).unwrap();
     musicbrainz_cache::schema::apply_schema(&mut client).unwrap();
     import::import_all(&mut client, &fixtures_dir()).unwrap();
     client

--- a/tests/idempotency_test.rs
+++ b/tests/idempotency_test.rs
@@ -1,0 +1,128 @@
+//! Per-step idempotency test for the MusicBrainz cache pipeline.
+//!
+//! Each pipeline step (Schema, Import, Filter, Indexes, Analyze) must be
+//! safe to run twice in a row without changing observable database state
+//! (table row counts). This is the safety net for `--resume`: if a run
+//! crashes between PG-commit and state-save, the next `--resume` will
+//! re-execute the step, and that re-execution must not duplicate data
+//! or fail.
+//!
+//! See CLAUDE.md "Resume safety" for the discipline this test enforces.
+//!
+//! Gated on `TEST_DATABASE_URL`: returns early when unset.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use musicbrainz_cache::{filter, import, schema};
+
+fn test_db_url() -> Option<String> {
+    std::env::var("TEST_DATABASE_URL").ok()
+}
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mbdump")
+}
+
+fn library_db_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/library.db")
+}
+
+/// Take a snapshot of every `mb_*` table's row count.
+///
+/// Returned as a `BTreeMap` for deterministic ordering in assertion diffs.
+fn take_snapshot(client: &mut postgres::Client) -> BTreeMap<String, i64> {
+    let rows = client
+        .query(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' \
+             AND tablename LIKE 'mb_%' ORDER BY tablename",
+            &[],
+        )
+        .unwrap();
+    let mut snapshot = BTreeMap::new();
+    for row in rows {
+        let table: String = row.get(0);
+        let count: i64 = client
+            .query_one(&format!("SELECT COUNT(*) FROM {table}"), &[])
+            .unwrap()
+            .get(0);
+        snapshot.insert(table, count);
+    }
+    snapshot
+}
+
+/// Take a snapshot of every `idx_mb_*` index's existence.
+fn index_snapshot(client: &mut postgres::Client) -> Vec<String> {
+    let rows = client
+        .query(
+            "SELECT indexname FROM pg_indexes WHERE schemaname = 'public' \
+             AND indexname LIKE 'idx_mb_%' ORDER BY indexname",
+            &[],
+        )
+        .unwrap();
+    rows.iter().map(|r| r.get::<_, String>(0)).collect()
+}
+
+/// Run a single pipeline step. Mirrors the closures inside `main.rs::run_step`
+/// but invokes them directly so the test can re-execute one step at a time.
+fn run_step(
+    step_name: &str,
+    client: &mut postgres::Client,
+    fixtures: &std::path::Path,
+    library_db: &std::path::Path,
+) -> anyhow::Result<()> {
+    match step_name {
+        "schema" => schema::apply_schema(client),
+        "import" => import::import_all(client, fixtures).map(|_| ()),
+        "filter" => {
+            let library_artists = filter::load_library_artists(library_db)?;
+            let matching = filter::find_matching_artist_ids(client, &library_artists)?;
+            filter::prune_to_matching(client, &matching)?;
+            Ok(())
+        }
+        "indexes" => schema::create_indexes(client),
+        "analyze" => schema::analyze_tables(client),
+        other => panic!("unknown step: {other}"),
+    }
+}
+
+#[test]
+#[ignore] // Requires PostgreSQL: TEST_DATABASE_URL=... cargo test --test idempotency_test -- --ignored
+fn test_each_step_is_idempotent() {
+    let Some(db_url) = test_db_url() else { return };
+    let mut client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
+
+    // Start every run from a clean schema.
+    schema::drop_all_tables(&mut client).unwrap();
+
+    let fixtures = fixtures_dir();
+    let library_db = library_db_path();
+
+    // Steps must run in order so each has its prerequisites satisfied
+    // (e.g. Filter needs imported data; Indexes needs filtered data).
+    for step in ["schema", "import", "filter", "indexes", "analyze"] {
+        // First execution: builds whatever this step builds on top of the
+        // prior step's output.
+        run_step(step, &mut client, &fixtures, &library_db)
+            .unwrap_or_else(|e| panic!("first run of step {step} failed: {e:#}"));
+        let snapshot1 = take_snapshot(&mut client);
+        let indexes1 = index_snapshot(&mut client);
+
+        // Second execution: same step against the same DB. Must succeed and
+        // must not change the row counts of any table -- this is the
+        // idempotency contract resume relies on.
+        run_step(step, &mut client, &fixtures, &library_db)
+            .unwrap_or_else(|e| panic!("second run of step {step} failed (not idempotent): {e:#}"));
+        let snapshot2 = take_snapshot(&mut client);
+        let indexes2 = index_snapshot(&mut client);
+
+        assert_eq!(
+            snapshot1, snapshot2,
+            "row counts changed when re-running step {step:?} -- step is not idempotent",
+        );
+        assert_eq!(
+            indexes1, indexes2,
+            "index set changed when re-running step {step:?} -- step is not idempotent",
+        );
+    }
+}

--- a/tests/import_test.rs
+++ b/tests/import_test.rs
@@ -159,6 +159,7 @@ fn test_dependency_order() {
 #[ignore] // Requires PostgreSQL: cargo test -- --ignored
 fn test_import_artist_table() {
     let mut client = postgres::Client::connect(&db_url(), postgres::NoTls).unwrap();
+    musicbrainz_cache::schema::drop_all_tables(&mut client).unwrap();
     musicbrainz_cache::schema::apply_schema(&mut client).unwrap();
 
     // Import reference tables first (area_type, gender, area) for FK satisfaction
@@ -203,6 +204,7 @@ fn test_import_artist_table() {
 #[ignore]
 fn test_import_null_handling() {
     let mut client = postgres::Client::connect(&db_url(), postgres::NoTls).unwrap();
+    musicbrainz_cache::schema::drop_all_tables(&mut client).unwrap();
     musicbrainz_cache::schema::apply_schema(&mut client).unwrap();
 
     // Import area_type, gender, area
@@ -233,6 +235,7 @@ fn test_import_null_handling() {
 #[ignore]
 fn test_import_column_extraction() {
     let mut client = postgres::Client::connect(&db_url(), postgres::NoTls).unwrap();
+    musicbrainz_cache::schema::drop_all_tables(&mut client).unwrap();
     musicbrainz_cache::schema::apply_schema(&mut client).unwrap();
 
     for spec in TABLES.iter().filter(|s| {
@@ -264,6 +267,7 @@ fn test_import_column_extraction() {
 #[ignore]
 fn test_import_all_tables() {
     let mut client = postgres::Client::connect(&db_url(), postgres::NoTls).unwrap();
+    musicbrainz_cache::schema::drop_all_tables(&mut client).unwrap();
     musicbrainz_cache::schema::apply_schema(&mut client).unwrap();
 
     let total = import::import_all(&mut client, &fixtures_dir()).unwrap();
@@ -299,6 +303,7 @@ fn test_import_all_tables() {
 #[ignore]
 fn test_import_skips_missing_file() {
     let mut client = postgres::Client::connect(&db_url(), postgres::NoTls).unwrap();
+    musicbrainz_cache::schema::drop_all_tables(&mut client).unwrap();
     musicbrainz_cache::schema::apply_schema(&mut client).unwrap();
 
     let missing_spec = TableSpec {
@@ -315,6 +320,7 @@ fn test_import_skips_missing_file() {
 #[ignore]
 fn test_import_recording_tables() {
     let mut client = postgres::Client::connect(&db_url(), postgres::NoTls).unwrap();
+    musicbrainz_cache::schema::drop_all_tables(&mut client).unwrap();
     musicbrainz_cache::schema::apply_schema(&mut client).unwrap();
 
     // Import all prerequisites

--- a/tests/integration/test_import_pipeline.py
+++ b/tests/integration/test_import_pipeline.py
@@ -71,8 +71,25 @@ EXPECTED_COUNTS = {
 }
 
 
+def _drop_all_mb_tables(conn: psycopg.Connection) -> None:
+    """Drop every mb_* table to give the test class a clean slate.
+
+    create_database.sql is now idempotent (CREATE TABLE IF NOT EXISTS) so it
+    no longer wipes existing data. Tests that want a fresh schema must drop
+    explicitly first.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' "
+            "AND tablename LIKE 'mb_%'"
+        )
+        for (table,) in cur.fetchall():
+            cur.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+
+
 def _apply_schema(conn: psycopg.Connection) -> None:
-    """Apply the database schema."""
+    """Drop existing mb_* tables and apply the database schema."""
+    _drop_all_mb_tables(conn)
     with conn.cursor() as cur:
         cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
 

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -77,6 +77,10 @@ const EXPECTED_FILTERED_ARTISTS: &[&str] = &["Autechre", "Jessica Pratt", "Stere
 
 fn set_up_imported_db(db_url: &str) -> postgres::Client {
     let mut client = postgres::Client::connect(db_url, postgres::NoTls).unwrap();
+    // apply_schema is idempotent (CREATE TABLE IF NOT EXISTS). Drop first
+    // to give each test a clean slate; otherwise rows from a prior test would
+    // make the (now-idempotent) Import step skip every table.
+    musicbrainz_cache::schema::drop_all_tables(&mut client).unwrap();
     musicbrainz_cache::schema::apply_schema(&mut client).unwrap();
     musicbrainz_cache::import::import_all(&mut client, &fixtures_dir()).unwrap();
     client

--- a/tests/resume_integration_test.rs
+++ b/tests/resume_integration_test.rs
@@ -170,9 +170,10 @@ fn test_partial_state_resume_runs_remaining_steps() {
     state.mark_complete(Step::Import);
     state.save(&state_path).unwrap();
 
-    // The seed run already created the secondary indexes; drop them so the
-    // resume's Indexes step can recreate them without "already exists" errors.
-    // (`schema::create_indexes` does not use IF NOT EXISTS by design.)
+    // create_indexes is idempotent (CREATE INDEX IF NOT EXISTS), so we
+    // could leave the indexes in place. We drop them here only to verify
+    // the resume's Indexes step actually re-creates them, not because it
+    // would fail otherwise.
     drop_mb_indexes(&db_url);
 
     // Resume: Schema + Import skipped, Filter/Indexes/Analyze run.


### PR DESCRIPTION
Closes #19. Follow-up to #14 / #15.

The `--resume` flow added in #15 lets the pipeline skip already-completed steps, but its safety hinges on each step being safe to re-run after a crash between PG-commit and state-save. Three steps were not safe.

## Audit findings

| Step | Was idempotent? | Fix |
|---|---|---|
| Schema | No -- dropped every `mb_*` table on entry, would erase imported data on re-run | `CREATE TABLE IF NOT EXISTS` / `CREATE EXTENSION IF NOT EXISTS` |
| Import | No -- COPY into a populated table tripped PRIMARY KEY UniqueViolations | Row-count guard in `import_table` |
| Filter | Yes -- copy-and-swap re-produces the same row set | (no change) |
| Indexes | No -- bare `CREATE INDEX` failed with "already exists" | `CREATE INDEX IF NOT EXISTS` |
| Analyze | Yes -- `ANALYZE` has no observable effect on data | (no change) |

The Indexes gap was already implicit in #15: the resume integration test had to manually drop every `idx_mb_*` index before re-running Indexes, with the comment "`schema::create_indexes` does not use IF NOT EXISTS by design". That comment is gone now.

## Commit-before-save audit

`run_step` in `main.rs` already satisfies commit-before-save: each step's PG work commits via `postgres::Client` autocommit before `run_step` calls `state.mark_complete` + `state.save`. No bug there. Documented the invariant in CLAUDE.md so future contributors don't invert the order.

## Other changes

- Added `schema::drop_all_tables` for tests and clean-rebuild workflows that need the destructive reset that used to live inside `apply_schema`.
- Updated parity, filter, import, and Python integration test setup helpers to call `drop_all_tables` before `apply_schema` -- otherwise the now-idempotent Import would skip every table because rows from the prior test would still be present.
- Added `tests/idempotency_test.rs` (1 test, `TEST_DATABASE_URL`-gated): runs each step twice in a row against the fixture DB and asserts row counts and the index set are unchanged on the second invocation. This is the safety net that catches regressions in any of the rules above.
- New "Resume safety" section in CLAUDE.md covers the two invariants and how each step satisfies idempotency.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --tests -- -D warnings -A clippy::manual_is_multiple_of`
- [x] `cargo test` (45 unit/state tests pass)
- [x] `cargo test -- --ignored --test-threads=1` against local Postgres (29 integration tests pass: 6 filter, 6 import, 12 parity, 4 resume, 1 idempotency)