### PR TITLE
Migrate CLI to standard build/import subcommand shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This repo is **Rust-only**. The pipeline previously lived in `scripts/*.py` (fil
 
 ## Architecture
 
-- `src/main.rs` -- CLI orchestrator (clap). Coordinates the pipeline: download -> schema -> import -> filter -> indexes -> analyze. Consumes `PipelineState` (see Resume) so `--resume` skips already-completed steps.
+- `src/main.rs` -- CLI orchestrator (clap). Exposes the standard WXYC cache-builder subcommands: `build` (full pipeline, resumable via `--resume`) and `import` (download + schema + TSV load, with `--fresh` to drop tables first). Shared `--database-url` / `--data-dir` / `--state-file` / `--resume` / `--fresh` come from `wxyc_etl::cli` (`DatabaseArgs`, `ResumableBuildArgs`, `ImportArgs`); the database URL falls back to `DATABASE_URL_MUSICBRAINZ` via `wxyc_etl::cli::resolve_database_url`. Legacy invocations without a subcommand are rewritten to `build` with a stderr deprecation warning. `build` consumes `PipelineState` so `--resume` skips already-completed steps.
 - `src/download.rs` -- HTTP download (`reqwest`) and tar.bz2 extraction (parallel `lbzip2`/`pbzip2` with Rust `bzip2`+`tar` fallback).
 - `src/import.rs` -- TSV import. Reads headerless MusicBrainz dump files, extracts columns by positional index, streams to PostgreSQL via COPY.
 - `src/filter.rs` -- Artist filtering. Loads WXYC library.db (SQLite), matches by normalized name + aliases, prunes via copy-and-swap.
@@ -35,7 +35,8 @@ cargo test
 cargo test -- --ignored --test-threads=1
 
 # Run the pipeline with fixture data
-cargo run -- --data-dir tests/fixtures --library-db tests/fixtures/library.db --skip-download
+DATABASE_URL_MUSICBRAINZ=postgresql://musicbrainz:musicbrainz@localhost:5434/musicbrainz \
+    cargo run -- build --data-dir tests/fixtures --library-db tests/fixtures/library.db --skip-download
 
 # Lint
 cargo clippy -- -D warnings -A clippy::manual_is_multiple_of
@@ -58,7 +59,7 @@ Uses copy-and-swap instead of DELETE to avoid dead tuples. Steps:
 
 ## Resume
 
-`main.rs` consumes `PipelineState` (`src/state.rs`). Each database-mutating step (Schema, Import, Filter, Indexes, Analyze) is wrapped by a `run_step` helper that checks `state.is_complete(...)` before running and persists the state file (default `./state`, override with `--state-file`) immediately on success. The Download step is not part of the state machine -- it has its own `--skip-download` flag and is naturally idempotent.
+`main.rs` consumes `PipelineState` (`src/state.rs`) inside the `build` subcommand. Each database-mutating step (Schema, Import, Filter, Indexes, Analyze) is wrapped by a `run_step` helper that checks `state.is_complete(...)` before running and persists the state file (default `./state.json`, override with `--state-file`) immediately on success. The Download step is not part of the state machine -- it has its own `--skip-download` flag and is naturally idempotent. The `import` subcommand runs a one-shot download + schema + TSV load and does not use a state file.
 
 CLI contract:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,6 +36,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -103,6 +127,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -177,6 +225,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,7 +238,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -360,6 +414,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +442,16 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "ctutils",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -569,8 +652,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -581,11 +680,17 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
@@ -646,12 +751,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -738,10 +860,11 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls",
+ "rustls 0.23.38",
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -971,6 +1094,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1162,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1206,15 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"
@@ -1111,12 +1264,158 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1126,6 +1425,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1182,6 +1521,22 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1292,7 +1647,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.10.1",
  "sha2",
  "stringprep",
 ]
@@ -1318,6 +1673,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1707,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.38",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.38",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,9 +1772,36 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -1359,7 +1811,45 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1467,6 +1957,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1474,6 +1966,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1481,6 +1974,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1512,6 +2006,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,13 +2041,29 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.11",
  "subtle",
  "zeroize",
 ]
@@ -1543,7 +2074,19 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1614,6 +2157,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "sentry"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5484316556650182f03b43d4c746ce0e3e48074a21e2f51244b648b6542e1066"
+dependencies = [
+ "httpdate",
+ "reqwest",
+ "rustls 0.22.4",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40aa225bb41e2ec9d7c90886834367f560efc1af028f1c5478a6cce6a59c463a"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8dd746da3d16cb8c39751619cefd4fcdbd6df9610f3310fd646b55f6e39910"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
+dependencies = [
+ "once_cell",
+ "rand 0.8.6",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,6 +2317,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1819,6 +2468,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny_http"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,7 +2627,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.10.1",
  "socket2",
  "tokio",
  "tokio-util",
@@ -1911,7 +2640,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -1980,7 +2709,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1990,6 +2731,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2003,6 +2787,15 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -2050,6 +2843,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls 0.23.38",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2867,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2072,6 +2881,24 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2233,6 +3060,34 @@ checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2464,6 +3319,7 @@ name = "wxyc-etl"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "crossbeam-channel",
  "csv",
  "env_logger",
@@ -2474,11 +3330,18 @@ dependencies = [
  "postgres",
  "rayon",
  "rusqlite",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "strsim",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
  "unicode-normalization",
  "unicode_categories",
+ "uuid",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -12,30 +12,76 @@ docker compose up -d
 cargo build --release
 
 # Run the full pipeline
-./target/release/musicbrainz-cache \
+export DATABASE_URL_MUSICBRAINZ=postgresql://musicbrainz:musicbrainz@localhost:5434/musicbrainz
+./target/release/musicbrainz-cache build \
     --data-dir data/ \
     --library-db data/library.db
 ```
 
 ## Usage
 
+`musicbrainz-cache` exposes two subcommands matching the standard WXYC cache-builder shape:
+
 ```
-musicbrainz-cache [OPTIONS] --data-dir <DATA_DIR>
+musicbrainz-cache build [OPTIONS]    # full pipeline (resumable)
+musicbrainz-cache import [OPTIONS]   # download + schema + TSV import only
+```
+
+### `build` — full pipeline
+
+Download the dump, apply the schema, import TSVs, filter to the WXYC library, build indexes, and ANALYZE. Each database-mutating step is idempotent and resumable via `--resume`.
+
+```
+musicbrainz-cache build [OPTIONS]
 
 Options:
-    --data-dir <DATA_DIR>          Directory for downloads and extracted files
-    --library-db <LIBRARY_DB>      Path to library.db (required unless --no-filter)
-    --database-url <DATABASE_URL>  PostgreSQL URL [default: postgresql://musicbrainz:musicbrainz@localhost:5434/musicbrainz]
-    --skip-download                Skip download, use existing files
-    --no-filter                    Import all artists without filtering
-    --dump-url <DUMP_URL>          Override dump URL (default: auto-detect latest)
-    --resume                       Resume from a prior interrupted run by reading the state file
-    --state-file <STATE_FILE>      Path to the pipeline state file [default: ./state]
+    --database-url <URL>           PostgreSQL URL (falls back to DATABASE_URL_MUSICBRAINZ)
+    --data-dir <PATH>              Working data directory [default: ./data]
+    --state-file <PATH>            Path to the pipeline state file [default: ./state.json]
+    --resume                       Resume from the existing state file
+    --library-db <PATH>            Path to library.db (required unless --no-filter)
+    --skip-download                Skip download, use existing files in --data-dir
+    --no-filter                    Import all artists without filtering to the WXYC library
+    --dump-url <URL>               Override dump URL (default: auto-detect latest)
 ```
+
+### `import` — fresh dump load
+
+Download (unless `--skip-download`), apply the schema, and import the dump TSVs. Use `--fresh` to drop the `mb_*` tables before importing.
+
+```
+musicbrainz-cache import [OPTIONS]
+
+Options:
+    --database-url <URL>           PostgreSQL URL (falls back to DATABASE_URL_MUSICBRAINZ)
+    --data-dir <PATH>              Working data directory [default: ./data]
+    --fresh                        Drop existing mb_* tables before importing
+    --skip-download                Skip download, use existing files in --data-dir
+    --dump-url <URL>               Override dump URL (default: auto-detect latest)
+```
+
+### Database URL
+
+Every cache builder follows the same `--database-url` convention: the flag wins, otherwise the tool's environment variable (`DATABASE_URL_MUSICBRAINZ` for this binary) is used. If neither is set, the binary errors out.
+
+```bash
+# Either of these works:
+export DATABASE_URL_MUSICBRAINZ=postgresql://musicbrainz:musicbrainz@localhost:5434/musicbrainz
+musicbrainz-cache build --data-dir data/ --library-db data/library.db
+
+musicbrainz-cache build \
+    --database-url postgresql://musicbrainz:musicbrainz@localhost:5434/musicbrainz \
+    --data-dir data/ \
+    --library-db data/library.db
+```
+
+### Legacy invocation (deprecated)
+
+Pre-#24 invocations without a subcommand (`musicbrainz-cache --data-dir ... --library-db ...`) still work but log a deprecation warning to stderr; they are rewritten internally to `musicbrainz-cache build ...`. New scripts should always use the explicit `build` or `import` subcommand.
 
 ## Resume
 
-The pipeline persists per-step completion to a state file (`--state-file`, default `./state`) after each successful step. To recover from a crashed or interrupted run, re-invoke the binary with `--resume`: previously-completed steps log a "Skipping ..." message and are not re-executed; the run picks up at the first incomplete step and continues to completion.
+The `build` pipeline persists per-step completion to a state file (`--state-file`, default `./state.json`) after each successful step. To recover from a crashed or interrupted run, re-invoke with `--resume`: previously-completed steps log a "Skipping ..." message and are not re-executed; the run picks up at the first incomplete step and continues to completion.
 
 State semantics:
 
@@ -51,7 +97,7 @@ Only the database-mutating steps (Schema, Import, Filter, Indexes, Analyze) part
 ## Pipeline Steps
 
 1. **Download** -- Fetches `mbdump.tar.bz2` and `mbdump-derived.tar.bz2` from data.metabrainz.org. Uses parallel decompression via lbzip2/pbzip2 when available.
-2. **Schema** -- Applies `schema/create_database.sql` (DROP + CREATE for 14 tables).
+2. **Schema** -- Applies `schema/create_database.sql` (CREATE TABLE IF NOT EXISTS for 14 tables).
 3. **Import** -- Reads headerless TSV files, extracts needed columns by positional index, streams to PostgreSQL via COPY. 14 tables imported in FK dependency order.
 4. **Filter** -- Matches MusicBrainz artists against WXYC library.db by normalized name and aliases. Prunes non-matching data using copy-and-swap for efficiency.
 5. **Index** -- Creates 14 secondary indexes from `schema/create_indexes.sql`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
 use anyhow::{bail, Context};
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 use musicbrainz_cache::state::{PipelineState, Step};
 use musicbrainz_cache::{download, filter, import, schema};
 use std::path::{Path, PathBuf};
+use wxyc_etl::cli::{resolve_database_url, DatabaseArgs, ImportArgs, ResumableBuildArgs};
+
+const DATABASE_ENV_NAME: &str = "DATABASE_URL_MUSICBRAINZ";
 
 /// MusicBrainz cache pipeline for WXYC.
 ///
@@ -11,49 +14,58 @@ use std::path::{Path, PathBuf};
 #[derive(Parser)]
 #[command(name = "musicbrainz-cache")]
 struct Cli {
-    /// Directory for downloads and extracted files.
-    #[arg(long)]
-    data_dir: PathBuf,
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Build the WXYC-filtered cache (download → schema → import → filter → indexes → analyze).
+    Build(BuildCmd),
+    /// Load a fresh MusicBrainz dump into PostgreSQL (download + schema + import).
+    Import(ImportCmd),
+}
+
+#[derive(Args)]
+struct BuildCmd {
+    #[command(flatten)]
+    db: DatabaseArgs,
+
+    #[command(flatten)]
+    build: ResumableBuildArgs,
 
     /// Path to library.db (required unless --no-filter is set).
     #[arg(long)]
     library_db: Option<PathBuf>,
 
-    /// PostgreSQL connection URL.
-    #[arg(
-        long,
-        default_value_t = default_database_url(),
-    )]
-    database_url: String,
-
-    /// Skip download, use existing files.
+    /// Skip download, use existing files in --data-dir.
     #[arg(long)]
     skip_download: bool,
 
-    /// Import all artists without filtering.
+    /// Import all artists without filtering to the WXYC library.
     #[arg(long)]
     no_filter: bool,
 
     /// Override dump URL (default: auto-detect latest).
     #[arg(long)]
     dump_url: Option<String>,
-
-    /// Resume an interrupted run by reading the state file and skipping
-    /// already-completed steps. If the state file does not exist, a fresh
-    /// run is performed (with a warning).
-    #[arg(long)]
-    resume: bool,
-
-    /// Path to the pipeline state file. Created during the run; consulted
-    /// on subsequent invocations when --resume is passed.
-    #[arg(long, default_value = "./state")]
-    state_file: PathBuf,
 }
 
-fn default_database_url() -> String {
-    std::env::var("DATABASE_URL").unwrap_or_else(|_| {
-        "postgresql://musicbrainz:musicbrainz@localhost:5434/musicbrainz".into()
-    })
+#[derive(Args)]
+struct ImportCmd {
+    #[command(flatten)]
+    db: DatabaseArgs,
+
+    #[command(flatten)]
+    import: ImportArgs,
+
+    /// Skip download, use existing files in --data-dir.
+    #[arg(long)]
+    skip_download: bool,
+
+    /// Override dump URL (default: auto-detect latest).
+    #[arg(long)]
+    dump_url: Option<String>,
 }
 
 fn wait_for_postgres(db_url: &str, timeout_secs: u64) -> anyhow::Result<()> {
@@ -127,33 +139,62 @@ where
     Ok(())
 }
 
-fn main() -> anyhow::Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+fn db_display(db_url: &str) -> &str {
+    if let Some(idx) = db_url.find('@') {
+        &db_url[idx + 1..]
+    } else {
+        db_url
+    }
+}
 
-    let cli = Cli::parse();
+fn download_dumps(data_dir: &Path, dump_url: Option<&str>) -> anyhow::Result<()> {
+    let dump_url = match dump_url {
+        Some(url) => url.to_string(),
+        None => download::find_latest_dump_url()?,
+    };
+
+    std::fs::create_dir_all(data_dir)?;
+
+    for &(archive_name, _) in download::ARCHIVES {
+        let archive_path = data_dir.join(archive_name);
+        download::download_file(&format!("{dump_url}/{archive_name}"), &archive_path)?;
+    }
+
+    let mbdump_dir = data_dir.join("mbdump");
+    for &(archive_name, needed_files) in download::ARCHIVES {
+        let archive_path = data_dir.join(archive_name);
+        if archive_path.exists() {
+            download::extract_tables(&archive_path, needed_files, &mbdump_dir)?;
+        } else {
+            log::error!("Archive not found: {}", archive_path.display());
+        }
+    }
+    Ok(())
+}
+
+fn run_build(cmd: BuildCmd) -> anyhow::Result<()> {
     let pipeline_start = std::time::Instant::now();
 
-    if !cli.no_filter && cli.library_db.is_none() {
+    if !cmd.no_filter && cmd.library_db.is_none() {
         bail!("--library-db required unless --no-filter is set");
     }
 
-    let mut state = init_state(&cli.state_file, cli.resume)?;
+    let database_url = resolve_database_url(&cmd.db, DATABASE_ENV_NAME)?;
+    let state_path = cmd.build.state_file.clone();
+    let data_dir = cmd.build.data_dir.clone();
 
-    let db_display = if let Some(idx) = cli.database_url.find('@') {
-        &cli.database_url[idx + 1..]
-    } else {
-        &cli.database_url
-    };
+    let mut state = init_state(&state_path, cmd.build.resume)?;
+
     log::info!("MusicBrainz cache pipeline starting");
-    log::info!("  Data dir: {}", cli.data_dir.display());
-    log::info!("  Database: {}", db_display);
-    log::info!("  State file: {}", cli.state_file.display());
+    log::info!("  Data dir: {}", data_dir.display());
+    log::info!("  Database: {}", db_display(&database_url));
+    log::info!("  State file: {}", state_path.display());
     log::info!(
         "  Filter: {}",
-        if cli.no_filter {
+        if cmd.no_filter {
             "disabled".to_string()
         } else {
-            cli.library_db
+            cmd.library_db
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or_default()
@@ -163,46 +204,22 @@ fn main() -> anyhow::Result<()> {
     // Download is intentionally not part of `PipelineState` -- it has its own
     // `--skip-download` flag and is naturally idempotent (existing archives
     // are reused). The resumable steps are the database-mutating ones below.
-    if !cli.skip_download {
-        let dump_url = match &cli.dump_url {
-            Some(url) => url.clone(),
-            None => download::find_latest_dump_url()?,
-        };
-
-        std::fs::create_dir_all(&cli.data_dir)?;
-
-        // Download archives sequentially (network-bound)
-        for &(archive_name, _) in download::ARCHIVES {
-            let archive_path = cli.data_dir.join(archive_name);
-            download::download_file(&format!("{dump_url}/{archive_name}"), &archive_path)?;
-        }
-
-        // Extract archives (could be parallelized, but kept simple)
-        let mbdump_dir = cli.data_dir.join("mbdump");
-        for &(archive_name, needed_files) in download::ARCHIVES {
-            let archive_path = cli.data_dir.join(archive_name);
-            if archive_path.exists() {
-                download::extract_tables(&archive_path, needed_files, &mbdump_dir)?;
-            } else {
-                log::error!("Archive not found: {}", archive_path.display());
-            }
-        }
+    if !cmd.skip_download {
+        download_dumps(&data_dir, cmd.dump_url.as_deref())?;
     }
 
-    let mbdump_dir = cli.data_dir.join("mbdump");
+    let mbdump_dir = data_dir.join("mbdump");
     if !mbdump_dir.exists() {
         bail!("mbdump directory not found: {}", mbdump_dir.display());
     }
 
-    // Wait for PostgreSQL and establish a single client used by every
-    // resumable step.
-    wait_for_postgres(&cli.database_url, 30)?;
-    let mut client = postgres::Client::connect(&cli.database_url, postgres::NoTls)
+    wait_for_postgres(&database_url, 30)?;
+    let mut client = postgres::Client::connect(&database_url, postgres::NoTls)
         .context("Failed to connect to PostgreSQL")?;
 
     run_step(
         &mut state,
-        &cli.state_file,
+        &state_path,
         Step::Schema,
         "Apply schema",
         || schema::apply_schema(&mut client),
@@ -210,17 +227,17 @@ fn main() -> anyhow::Result<()> {
 
     run_step(
         &mut state,
-        &cli.state_file,
+        &state_path,
         Step::Import,
         "Import TSV files",
         || import::import_all(&mut client, &mbdump_dir).map(|_| ()),
     )?;
 
-    if !cli.no_filter {
-        let library_db = cli.library_db.as_ref().unwrap().clone();
+    if !cmd.no_filter {
+        let library_db = cmd.library_db.as_ref().unwrap().clone();
         run_step(
             &mut state,
-            &cli.state_file,
+            &state_path,
             Step::Filter,
             "Filter to WXYC library artists",
             || {
@@ -235,29 +252,219 @@ fn main() -> anyhow::Result<()> {
         // With --no-filter we never run the Filter step, but for resume
         // accounting we still mark it complete so subsequent steps advance.
         state.mark_complete(Step::Filter);
-        state.save(&cli.state_file).with_context(|| {
-            format!("Failed to persist state file: {}", cli.state_file.display())
-        })?;
+        state
+            .save(&state_path)
+            .with_context(|| format!("Failed to persist state file: {}", state_path.display()))?;
         log::info!("Skipping Filter (--no-filter set)");
     }
 
     run_step(
         &mut state,
-        &cli.state_file,
+        &state_path,
         Step::Indexes,
         "Create indexes",
         || schema::create_indexes(&mut client),
     )?;
 
-    run_step(
-        &mut state,
-        &cli.state_file,
-        Step::Analyze,
-        "Analyze",
-        || schema::analyze_tables(&mut client),
-    )?;
+    run_step(&mut state, &state_path, Step::Analyze, "Analyze", || {
+        schema::analyze_tables(&mut client)
+    })?;
 
     let elapsed = pipeline_start.elapsed();
     log::info!("Pipeline complete in {:.1}s", elapsed.as_secs_f64());
     Ok(())
+}
+
+fn run_import(cmd: ImportCmd) -> anyhow::Result<()> {
+    let database_url = resolve_database_url(&cmd.db, DATABASE_ENV_NAME)?;
+    let data_dir = cmd.import.data_dir.clone();
+
+    log::info!("MusicBrainz import starting");
+    log::info!("  Data dir: {}", data_dir.display());
+    log::info!("  Database: {}", db_display(&database_url));
+    log::info!("  Fresh: {}", cmd.import.fresh);
+
+    if !cmd.skip_download {
+        download_dumps(&data_dir, cmd.dump_url.as_deref())?;
+    }
+
+    let mbdump_dir = data_dir.join("mbdump");
+    if !mbdump_dir.exists() {
+        bail!("mbdump directory not found: {}", mbdump_dir.display());
+    }
+
+    wait_for_postgres(&database_url, 30)?;
+    let mut client = postgres::Client::connect(&database_url, postgres::NoTls)
+        .context("Failed to connect to PostgreSQL")?;
+
+    if cmd.import.fresh {
+        log::info!("=== Drop existing tables (--fresh) ===");
+        schema::drop_all_tables(&mut client)?;
+    }
+
+    log::info!("=== Apply schema ===");
+    schema::apply_schema(&mut client)?;
+
+    log::info!("=== Import TSV files ===");
+    import::import_all(&mut client, &mbdump_dir)?;
+
+    log::info!("Import complete.");
+    Ok(())
+}
+
+/// Pre-process argv to support the legacy invocation shape (no subcommand).
+///
+/// Before issue #24 the binary accepted top-level flags like
+/// `musicbrainz-cache --data-dir X --library-db Y`. The current convention
+/// requires a `build` or `import` subcommand. To avoid breaking existing
+/// scripts and CI, we detect the legacy form (first arg is a flag) and
+/// rewrite it to `musicbrainz-cache build <flags>...` with a stderr
+/// deprecation warning.
+fn apply_legacy_shim(mut args: Vec<String>) -> Vec<String> {
+    if args.len() < 2 {
+        return args;
+    }
+    let first = &args[1];
+    // Pass clap's own --help/--version through unchanged.
+    if matches!(first.as_str(), "--help" | "-h" | "--version" | "-V") {
+        return args;
+    }
+    if first.starts_with('-') {
+        eprintln!(
+            "warning: invoking `musicbrainz-cache` without a subcommand is deprecated; \
+             use `musicbrainz-cache build [...]` instead."
+        );
+        args.insert(1, "build".to_string());
+    }
+    args
+}
+
+fn main() -> anyhow::Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let args = apply_legacy_shim(std::env::args().collect());
+    let cli = Cli::parse_from(args);
+
+    match cli.command {
+        Command::Build(cmd) => run_build(cmd),
+        Command::Import(cmd) => run_import(cmd),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_shim_inserts_build_when_first_arg_is_flag() {
+        let args = vec![
+            "musicbrainz-cache".into(),
+            "--data-dir".into(),
+            "data/".into(),
+        ];
+        let shimmed = apply_legacy_shim(args);
+        assert_eq!(
+            shimmed,
+            vec![
+                "musicbrainz-cache".to_string(),
+                "build".into(),
+                "--data-dir".into(),
+                "data/".into()
+            ]
+        );
+    }
+
+    #[test]
+    fn legacy_shim_passes_through_subcommand() {
+        let args = vec![
+            "musicbrainz-cache".into(),
+            "build".into(),
+            "--resume".into(),
+        ];
+        let shimmed = apply_legacy_shim(args.clone());
+        assert_eq!(shimmed, args);
+    }
+
+    #[test]
+    fn legacy_shim_passes_through_import_subcommand() {
+        let args = vec![
+            "musicbrainz-cache".into(),
+            "import".into(),
+            "--fresh".into(),
+        ];
+        let shimmed = apply_legacy_shim(args.clone());
+        assert_eq!(shimmed, args);
+    }
+
+    #[test]
+    fn legacy_shim_preserves_help_and_version() {
+        for flag in ["--help", "-h", "--version", "-V"] {
+            let args = vec!["musicbrainz-cache".into(), flag.into()];
+            let shimmed = apply_legacy_shim(args.clone());
+            assert_eq!(shimmed, args);
+        }
+    }
+
+    #[test]
+    fn legacy_shim_no_args() {
+        let args = vec!["musicbrainz-cache".into()];
+        let shimmed = apply_legacy_shim(args.clone());
+        assert_eq!(shimmed, args);
+    }
+
+    #[test]
+    fn build_subcommand_parses_shared_flags() {
+        let cli = Cli::try_parse_from([
+            "musicbrainz-cache",
+            "build",
+            "--database-url",
+            "postgresql://example/db",
+            "--data-dir",
+            "/tmp/data",
+            "--state-file",
+            "/tmp/state.json",
+            "--library-db",
+            "/tmp/library.db",
+            "--resume",
+        ])
+        .unwrap();
+        let Command::Build(b) = cli.command else {
+            panic!("expected Build subcommand");
+        };
+        assert_eq!(
+            b.db.database_url.as_deref(),
+            Some("postgresql://example/db")
+        );
+        assert_eq!(b.build.data_dir, PathBuf::from("/tmp/data"));
+        assert_eq!(b.build.state_file, PathBuf::from("/tmp/state.json"));
+        assert_eq!(b.library_db, Some(PathBuf::from("/tmp/library.db")));
+        assert!(b.build.resume);
+    }
+
+    #[test]
+    fn import_subcommand_parses_fresh_flag() {
+        let cli = Cli::try_parse_from([
+            "musicbrainz-cache",
+            "import",
+            "--fresh",
+            "--data-dir",
+            "/tmp/data",
+        ])
+        .unwrap();
+        let Command::Import(i) = cli.command else {
+            panic!("expected Import subcommand");
+        };
+        assert!(i.import.fresh);
+        assert_eq!(i.import.data_dir, PathBuf::from("/tmp/data"));
+    }
+
+    #[test]
+    fn database_url_falls_back_to_env_var() {
+        // Smoke test that the binary's env name is wired up correctly.
+        let args = DatabaseArgs { database_url: None };
+        std::env::set_var(DATABASE_ENV_NAME, "postgresql://envhost/db");
+        let url = resolve_database_url(&args, DATABASE_ENV_NAME).unwrap();
+        std::env::remove_var(DATABASE_ENV_NAME);
+        assert_eq!(url, "postgresql://envhost/db");
+    }
 }


### PR DESCRIPTION
## Summary

- Replace the local `clap` derive with `wxyc_etl::cli` shared helpers (`DatabaseArgs`, `ResumableBuildArgs`, `ImportArgs`) and split the entrypoint into the convention-matching `build` (resumable full pipeline) and `import` (download + schema + TSV load, with `--fresh`) subcommands.
- Wire `resolve_database_url(&args, "DATABASE_URL_MUSICBRAINZ")` so the `--database-url` flag falls back to the standard env var.
- Preserve backward compatibility for pre-subcommand invocations: argv is shimmed to `build [...]` with a stderr deprecation warning, so existing scripts and the resume integration tests keep working.

## Test plan

- [x] `cargo test --lib --bin musicbrainz-cache` (added unit tests for the legacy shim + subcommand parsing + env-var fallback)
- [ ] CI: lint (`cargo fmt --check`, `cargo clippy -- -D warnings`)
- [ ] CI: `cargo test` (HTTP download + unit tests)
- [ ] CI: `cargo test -- --ignored --test-threads=1` (resume_integration_test, parity_test, idempotency_test) against the workflow's PostgreSQL service

## Tracking

- Parent epic: WXYC/wxyc-etl#45
- Closes #24