### PR TITLE
Add scheduled monthly rebuild workflow

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -1,0 +1,71 @@
+name: Rebuild Cache
+
+on:
+  schedule:
+    # 06:00 UTC on the 5th of each month. Offset from discogs-etl's monthly
+    # rebuild so two ~tens-of-GB jobs don't co-run.
+    - cron: "0 6 5 * *"
+  workflow_dispatch:
+    inputs:
+      dump_url:
+        description: "Override MusicBrainz dump URL (optional)"
+        required: false
+      skip_download:
+        description: "Skip download, reuse mbdump in $DATA_DIR"
+        type: boolean
+        default: false
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    # The full pipeline downloads ~6 GB compressed, expands to ~30 GB on disk,
+    # and imports + filters + indexes against PostgreSQL. Allow plenty of
+    # headroom; tighten this once we have real production timings.
+    # TODO(runner-capacity): if monthly runs start exceeding the GitHub-hosted
+    # runner's 6h job limit or 14 GB RAM, move this to a self-hosted runner.
+    timeout-minutes: 350
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout wxyc-etl at expected relative path
+        run: git clone --depth 1 https://github.com/WXYC/wxyc-etl.git "$GITHUB_WORKSPACE/../../../wxyc-etl"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install parallel bzip2 decompressor
+        run: sudo apt-get update && sudo apt-get install -y lbzip2
+
+      - name: Build musicbrainz-cache
+        run: cargo build --release
+
+      - name: Fetch library.db from library-metadata-lookup release
+        # library.db is published to the streaming-data-v1 release tag on
+        # WXYC/library-metadata-lookup by discogs-etl's daily Sync Library job.
+        run: |
+          mkdir -p data
+          gh release download streaming-data-v1 \
+            --repo WXYC/library-metadata-lookup \
+            --pattern library.db \
+            --dir data
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Run musicbrainz-cache build
+        run: |
+          set -euo pipefail
+          args=(build --data-dir data --library-db data/library.db --state-file data/state.json)
+          if [[ -n "${DUMP_URL_INPUT:-}" ]]; then
+            args+=(--dump-url "$DUMP_URL_INPUT")
+          fi
+          if [[ "${SKIP_DOWNLOAD_INPUT:-false}" == "true" ]]; then
+            args+=(--skip-download)
+          fi
+          ./target/release/musicbrainz-cache "${args[@]}"
+        env:
+          DATABASE_URL_MUSICBRAINZ: ${{ secrets.DATABASE_URL_MUSICBRAINZ }}
+          # TODO(sentry-dsn): provision SENTRY_DSN as a repo/org secret so
+          # cron failures forward to Sentry. Without it, JSON logs still ship
+          # to the workflow log; Sentry stays inactive.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          DUMP_URL_INPUT: ${{ inputs.dump_url }}
+          SKIP_DOWNLOAD_INPUT: ${{ inputs.skip_download }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,16 @@ This repo is **Rust-only**. The pipeline previously lived in `scripts/*.py` (fil
 
 When `SENTRY_DSN` is set in the environment, panics and `tracing::error!` events forward to Sentry tagged with the same fields. With no DSN, Sentry stays inactive but JSON logging still initializes — provisioning the DSN in Railway / GitHub Actions / EC2 is tracked separately (see the `TODO(sentry-dsn)` comment in `main.rs`).
 
+## Scheduling
+
+The full rebuild runs on GitHub Actions via `.github/workflows/rebuild-cache.yml`:
+
+- **Cron**: `0 6 5 * *` — 06:00 UTC on the 5th of each month. Offset from `discogs-etl`'s monthly rebuild so two large jobs don't co-run.
+- **Manual**: `workflow_dispatch` exposes two inputs: `dump_url` (override the auto-detected MusicBrainz dump URL) and `skip_download` (reuse `mbdump` already on the runner — only useful when chaining a re-run after `dump_url` was wrong).
+- **Library DB**: fetched from the `streaming-data-v1` release on `WXYC/library-metadata-lookup` (where `discogs-etl`'s daily Sync Library job publishes it).
+- **Required secrets** (operator-provisioned, not created here): `DATABASE_URL_MUSICBRAINZ`, optional `SENTRY_DSN`.
+- **Runner capacity**: the job uses `ubuntu-latest` with a 350-minute timeout. The dump is ~6 GB compressed / ~30 GB extracted, which fits the GitHub-hosted runner's disk budget but not by a wide margin. If runs start failing on disk or the 6h job limit, move to a self-hosted runner (TODO comment in the workflow).
+
 ## Dependencies
 
 - **wxyc-etl** (path dependency) -- `text::normalize_artist_name` for name normalization, `schema::musicbrainz` for table constants, `logger::init` for Sentry + structured JSON logs.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/rebuild-cache.yml` with a monthly `schedule` (06:00 UTC on the 5th, offset from discogs-etl) and a `workflow_dispatch` override exposing `dump_url` and `skip_download` inputs.
- Pulls `library.db` from the `streaming-data-v1` release on `WXYC/library-metadata-lookup` (the same artifact `discogs-etl`'s Sync Library workflow keeps current).
- Runs `musicbrainz-cache build` with `DATABASE_URL_MUSICBRAINZ` and optional `SENTRY_DSN` injected from repo secrets. TODO comments call out (a) operator-side DSN provisioning and (b) escape hatch to a self-hosted runner if the GitHub-hosted timeout/disk budget gets tight.
- Documents the schedule, inputs, library-db source, and runner-capacity caveat in a new `Scheduling` section in `CLAUDE.md`.

## Test plan

- [x] `actionlint .github/workflows/*.yml` passes
- [x] `cargo fmt --check` passes (no Rust changes)
- [ ] First scheduled run on the 5th of next month verifies real end-to-end behavior (operator follow-up, depends on `DATABASE_URL_MUSICBRAINZ` being provisioned)

Closes #26
Tracking: WXYC/wxyc-etl#47