### PR TITLE
Adopt sqlx-cli with 0001_initial baseline migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ This repo is **Rust-only**. The pipeline previously lived in `scripts/*.py` (fil
 - `src/filter.rs` -- Artist filtering. Loads WXYC library.db (SQLite), matches by normalized name + aliases, prunes via copy-and-swap.
 - `src/schema.rs` -- DDL application (create_database.sql, create_indexes.sql) and ANALYZE.
 - `src/state.rs` -- Pipeline state persistence for resume support. Records completed steps so interrupted runs can resume.
-- `schema/` -- PostgreSQL DDL (14 tables) and secondary indexes (14 indexes).
+- `schema/` -- PostgreSQL DDL (14 tables) and secondary indexes (14 indexes). Applied at runtime by `apply_schema()`. Mirrored as the baseline `migrations/0001_initial.sql` for sqlx-cli (see "Migrations").
+- `migrations/` -- sqlx-cli migration files. `0001_initial.sql` is a snapshot of `schema/*.sql`; future schema changes ship as `0002_*`, `0003_*`, etc. Not yet wired into the deploy path (see "Migrations").
 
 ## Observability
 
@@ -72,6 +73,39 @@ Uses copy-and-swap instead of DELETE to avoid dead tuples. Steps:
 2. Save kept rows for each table into temp tables (cascading from artists -> credits -> recordings -> tracks)
 3. TRUNCATE all tables together (satisfies FK constraints)
 4. Re-insert kept rows from temp tables
+
+## Migrations
+
+Schema evolution uses [`sqlx-cli`](https://crates.io/crates/sqlx-cli). Migration files live in `migrations/` at the repo root and are applied in lex order (`0001_initial.sql`, `0002_*.sql`, ...).
+
+**Status**: the runtime deploy path still applies `schema/create_database.sql` + `schema/create_indexes.sql` via `src/schema.rs::apply_schema()`. `sqlx migrate run` is **not yet wired into the deploy** -- that switch lands in [WXYC/wxyc-etl#56](https://github.com/WXYC/wxyc-etl/issues/56). The baseline file exists today so future schema changes can ship as numbered migrations starting at `0002_*` instead of edit-and-rebuild.
+
+**Install the CLI** (not a Cargo dep -- runtime uses the `postgres` crate):
+
+```bash
+cargo install sqlx-cli --no-default-features --features postgres
+```
+
+**Add a new migration**:
+
+```bash
+# Generates migrations/<timestamp>_<name>.sql (or 0002_<name>.sql with --sequential)
+sqlx migrate add --source migrations <name>
+```
+
+**Run migrations against an empty Postgres** (smoke test):
+
+```bash
+docker compose up -d
+createdb -h localhost -p 5434 -U musicbrainz musicbrainz_migrations_test
+sqlx migrate run \
+    --database-url postgresql://musicbrainz:musicbrainz@localhost:5434/musicbrainz_migrations_test \
+    --source migrations
+```
+
+**Stamping prod**: existing prod databases already have the schema applied via `apply_schema()`. When #56 flips the deploy to `sqlx migrate run`, the first deploy will run `sqlx migrate run --target-version 0` (or equivalent insert into `_sqlx_migrations`) so prod is recorded at `0001_initial` without re-applying. Until then, do not run `sqlx migrate run` against prod -- it would no-op on the schema (every statement is `IF NOT EXISTS`) but would create the `_sqlx_migrations` tracking table outside of the planned stamping flow.
+
+**Idempotency**: every statement in `0001_initial.sql` is re-runnable (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`). Subsequent migrations should aim for the same property where reasonable so re-applying after partial failure doesn't corrupt state.
 
 ## Resume
 

--- a/migrations/0001_initial.sql
+++ b/migrations/0001_initial.sql
@@ -1,0 +1,213 @@
+-- Baseline migration for the WXYC musicbrainz-cache schema.
+--
+-- Snapshot of the schema applied today via src/schema.rs::apply_schema()
+-- (concatenation of schema/create_database.sql followed by
+-- schema/create_indexes.sql). The runtime path still uses apply_schema();
+-- this baseline exists so that future schema changes can ship as
+-- numbered sqlx migrations (0002_*, 0003_*, ...). Switching the runtime
+-- path to `sqlx migrate run` lands separately in WXYC/wxyc-etl#56.
+--
+-- Idempotency: every statement is re-runnable so existing prod databases
+-- can be stamped at 0001_initial without re-applying. See CLAUDE.md
+-- "Migrations" for the stamp procedure.
+
+-- =============================================================================
+-- create_database.sql
+-- =============================================================================
+
+-- MusicBrainz cache schema for WXYC genre/area analysis.
+-- Imports a subset of MusicBrainz tables relevant to artist classification.
+-- Table prefix mb_ to avoid conflicts when sharing a PostgreSQL instance.
+--
+-- Idempotency: every statement is re-runnable. Re-applying the schema against
+-- a populated database is a no-op and does NOT drop existing data. This is a
+-- requirement of the `--resume` flow (see CLAUDE.md "Resume safety"). Tests:
+-- tests/idempotency_test.rs.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- Reference tables
+
+CREATE TABLE IF NOT EXISTS mb_area_type (
+    id          integer PRIMARY KEY,
+    name        text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mb_gender (
+    id          integer PRIMARY KEY,
+    name        text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mb_tag (
+    id          integer PRIMARY KEY,
+    name        text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mb_area (
+    id          integer PRIMARY KEY,
+    name        text NOT NULL,
+    type        integer REFERENCES mb_area_type(id)
+);
+
+CREATE TABLE IF NOT EXISTS mb_country_area (
+    area        integer PRIMARY KEY REFERENCES mb_area(id)
+);
+
+-- Core artist tables
+
+CREATE TABLE IF NOT EXISTS mb_artist (
+    id          integer PRIMARY KEY,
+    name        text NOT NULL,
+    sort_name   text NOT NULL,
+    type        integer,
+    area        integer REFERENCES mb_area(id),
+    gender      integer REFERENCES mb_gender(id),
+    begin_area  integer REFERENCES mb_area(id),
+    comment     text NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS mb_artist_alias (
+    id          integer PRIMARY KEY,
+    artist      integer NOT NULL REFERENCES mb_artist(id) ON DELETE CASCADE,
+    name        text NOT NULL,
+    sort_name   text NOT NULL,
+    locale      text,
+    type        integer,
+    primary_for_locale boolean NOT NULL DEFAULT false
+);
+
+CREATE TABLE IF NOT EXISTS mb_artist_tag (
+    artist      integer NOT NULL REFERENCES mb_artist(id) ON DELETE CASCADE,
+    tag         integer NOT NULL REFERENCES mb_tag(id),
+    count       integer NOT NULL,
+    PRIMARY KEY (artist, tag)
+);
+
+-- Release matching tables
+
+CREATE TABLE IF NOT EXISTS mb_artist_credit (
+    id          integer PRIMARY KEY,
+    name        text NOT NULL,
+    artist_count smallint NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mb_artist_credit_name (
+    artist_credit integer NOT NULL REFERENCES mb_artist_credit(id) ON DELETE CASCADE,
+    position    smallint NOT NULL,
+    artist      integer NOT NULL REFERENCES mb_artist(id) ON DELETE CASCADE,
+    name        text NOT NULL,
+    join_phrase text NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS mb_release_group (
+    id          integer PRIMARY KEY,
+    name        text NOT NULL,
+    artist_credit integer NOT NULL REFERENCES mb_artist_credit(id),
+    type        integer
+);
+
+-- Recording tables (for AcousticBrainz feature lookup)
+
+CREATE TABLE IF NOT EXISTS mb_recording (
+    id          integer PRIMARY KEY,
+    gid         uuid NOT NULL,          -- MusicBrainz recording MBID
+    name        text NOT NULL,
+    artist_credit integer REFERENCES mb_artist_credit(id),
+    length      integer                  -- milliseconds
+);
+
+CREATE TABLE IF NOT EXISTS mb_medium (
+    id          integer PRIMARY KEY,
+    release     integer,
+    position    integer,
+    format      integer
+);
+
+CREATE TABLE IF NOT EXISTS mb_track (
+    id          integer PRIMARY KEY,
+    recording   integer NOT NULL REFERENCES mb_recording(id),
+    medium      integer NOT NULL REFERENCES mb_medium(id),
+    position    integer NOT NULL,
+    name        text NOT NULL,
+    artist_credit integer REFERENCES mb_artist_credit(id),
+    length      integer
+);
+
+-- URL/streaming tables
+
+CREATE TABLE IF NOT EXISTS mb_url (
+    id          integer PRIMARY KEY,
+    gid         uuid NOT NULL,
+    url         text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mb_link_type (
+    id          integer PRIMARY KEY,
+    name        text NOT NULL,
+    entity_type0 text NOT NULL,
+    entity_type1 text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mb_link (
+    id          integer PRIMARY KEY,
+    link_type   integer NOT NULL REFERENCES mb_link_type(id)
+);
+
+CREATE TABLE IF NOT EXISTS mb_release (
+    id              integer PRIMARY KEY,
+    gid             uuid NOT NULL,
+    name            text NOT NULL,
+    artist_credit   integer NOT NULL REFERENCES mb_artist_credit(id),
+    release_group   integer NOT NULL REFERENCES mb_release_group(id)
+);
+
+CREATE TABLE IF NOT EXISTS mb_l_release_group_url (
+    id          integer PRIMARY KEY,
+    link        integer NOT NULL REFERENCES mb_link(id),
+    release_group integer NOT NULL REFERENCES mb_release_group(id),
+    url         integer NOT NULL REFERENCES mb_url(id)
+);
+
+CREATE TABLE IF NOT EXISTS mb_l_release_url (
+    id          integer PRIMARY KEY,
+    link        integer NOT NULL REFERENCES mb_link(id),
+    release     integer NOT NULL REFERENCES mb_release(id),
+    url         integer NOT NULL REFERENCES mb_url(id)
+);
+
+-- Indexes are created separately after bulk import (see create_indexes.sql).
+
+-- =============================================================================
+-- create_indexes.sql
+-- =============================================================================
+
+-- Secondary indexes for MusicBrainz cache tables.
+-- Applied after bulk import and filtering for faster pipeline throughput.
+--
+-- Idempotency: every CREATE INDEX uses IF NOT EXISTS so the Indexes step
+-- can be re-run safely under `--resume` (see CLAUDE.md "Resume safety").
+
+CREATE INDEX IF NOT EXISTS idx_mb_recording_gid ON mb_recording(gid);
+CREATE INDEX IF NOT EXISTS idx_mb_recording_credit ON mb_recording(artist_credit);
+CREATE INDEX IF NOT EXISTS idx_mb_track_recording ON mb_track(recording);
+CREATE INDEX IF NOT EXISTS idx_mb_track_medium ON mb_track(medium);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_name_lower ON mb_artist (lower(name));
+CREATE INDEX IF NOT EXISTS idx_mb_artist_area ON mb_artist (area);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_alias_artist ON mb_artist_alias (artist);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_alias_name_lower ON mb_artist_alias (lower(name));
+CREATE INDEX IF NOT EXISTS idx_mb_artist_tag_artist ON mb_artist_tag (artist);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_tag_tag ON mb_artist_tag (tag);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_credit_name_artist ON mb_artist_credit_name (artist);
+CREATE INDEX IF NOT EXISTS idx_mb_artist_credit_name_credit ON mb_artist_credit_name (artist_credit);
+CREATE INDEX IF NOT EXISTS idx_mb_release_group_credit ON mb_release_group (artist_credit);
+CREATE INDEX IF NOT EXISTS idx_mb_area_type ON mb_area (type);
+CREATE INDEX IF NOT EXISTS idx_mb_url_gid ON mb_url(gid);
+CREATE INDEX IF NOT EXISTS idx_mb_release_gid ON mb_release(gid);
+CREATE INDEX IF NOT EXISTS idx_mb_release_release_group ON mb_release(release_group);
+CREATE INDEX IF NOT EXISTS idx_mb_release_credit ON mb_release(artist_credit);
+CREATE INDEX IF NOT EXISTS idx_mb_l_release_group_url_rg ON mb_l_release_group_url(release_group);
+CREATE INDEX IF NOT EXISTS idx_mb_l_release_group_url_url ON mb_l_release_group_url(url);
+CREATE INDEX IF NOT EXISTS idx_mb_l_release_url_release ON mb_l_release_url(release);
+CREATE INDEX IF NOT EXISTS idx_mb_l_release_url_url ON mb_l_release_url(url);
+CREATE INDEX IF NOT EXISTS idx_mb_link_type ON mb_link(link_type);


### PR DESCRIPTION
## Summary

- Snapshot the current schema as `migrations/0001_initial.sql` (concatenation of `schema/create_database.sql` + `schema/create_indexes.sql`) so future schema changes can ship as numbered sqlx migrations starting at `0002_*`.
- Document `cargo install sqlx-cli`, how to add migrations, and the pending stamp-prod flow in `CLAUDE.md` under a new "Migrations" section.
- Runtime / deploy path is **unchanged** — `apply_schema()` still drives schema application. Switching the deploy to `sqlx migrate run` and stamping prod at `0001_initial` lands separately in WXYC/wxyc-etl#56.

## Verification

```
docker exec staging-postgres-1 psql -U postgres -c "CREATE DATABASE mb_migrations_test;"
sqlx migrate run --database-url postgresql://postgres:postgres@localhost:5434/mb_migrations_test --source migrations
# -> Applied 1/migrate initial
```

`pg_dump` of the migration-applied DB vs. `apply_schema()`-applied DB shows only the expected `_sqlx_migrations` tracking table (and cosmetic `\restrict` tokens). 20 tables / 23 indexes parity confirmed.

## Test plan

- [ ] CI green (`cargo fmt --check`, `cargo clippy`, `cargo test`)
- [ ] `sqlx migrate run --source migrations` applies cleanly to an empty Postgres
- [ ] No runtime / deploy behavior change — `apply_schema()` still authoritative until #56

## Tracking

Closes #27. Parent epic: WXYC/wxyc-etl#48.