### PR TITLE
Add pg_trgm GIN index on mb_artist(lower(name)) for fuzzy search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This repo is **Rust-only**. The pipeline previously lived in `scripts/*.py` (fil
 - `src/filter.rs` -- Artist filtering. Loads WXYC library.db (SQLite), matches by normalized name + aliases, prunes via copy-and-swap.
 - `src/schema.rs` -- DDL application (create_database.sql, create_indexes.sql) and ANALYZE.
 - `src/state.rs` -- Pipeline state persistence for resume support. Records completed steps so interrupted runs can resume.
-- `schema/` -- PostgreSQL DDL (14 tables) and secondary indexes (14 indexes). Applied at runtime by `apply_schema()`. Mirrored as the baseline `migrations/0001_initial.sql` for sqlx-cli (see "Migrations").
+- `schema/` -- PostgreSQL DDL (14 tables) and secondary indexes (15 indexes). Applied at runtime by `apply_schema()`. Mirrored as the baseline `migrations/0001_initial.sql` for sqlx-cli (see "Migrations"); subsequent index changes ship as numbered migrations (`0002_*.sql` ...).
 - `migrations/` -- sqlx-cli migration files. `0001_initial.sql` is a snapshot of `schema/*.sql`; future schema changes ship as `0002_*`, `0003_*`, etc. Not yet wired into the deploy path (see "Migrations").
 
 ## Observability

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Only the database-mutating steps (Schema, Import, Filter, Indexes, Analyze) part
 2. **Schema** -- Applies `schema/create_database.sql` (CREATE TABLE IF NOT EXISTS for 14 tables).
 3. **Import** -- Reads headerless TSV files, extracts needed columns by positional index, streams to PostgreSQL via COPY. 14 tables imported in FK dependency order.
 4. **Filter** -- Matches MusicBrainz artists against WXYC library.db by normalized name and aliases. Prunes non-matching data using copy-and-swap for efficiency.
-5. **Index** -- Creates 14 secondary indexes from `schema/create_indexes.sql`.
+5. **Index** -- Creates 15 secondary indexes from `schema/create_indexes.sql` (includes a `pg_trgm` GIN index on `lower(mb_artist.name)` for LML's fuzzy-search fallback).
 6. **Analyze** -- Runs ANALYZE on all tables for query planner statistics.
 
 ## Tables

--- a/migrations/0002_mb_artist_name_trgm_index.sql
+++ b/migrations/0002_mb_artist_name_trgm_index.sql
@@ -1,0 +1,14 @@
+-- Add a pg_trgm GIN index on lower(mb_artist.name) for fuzzy artist search.
+--
+-- LML's external-cache fallback (lookup/external_search.py::_MB_ARTIST_FUZZY_SQL)
+-- runs `WHERE lower(name) % lower($1)` against mb_artist. Without a trigram
+-- index, `%` falls back to a sequential scan of the filtered mb_artist table
+-- on every call. The 2026-04-27 lossy-mojibake matcher run (815 calls) took
+-- ~25 minutes; with this index it drops to a few minutes.
+--
+-- pg_trgm is enabled by 0001_initial.sql (CREATE EXTENSION IF NOT EXISTS pg_trgm).
+--
+-- Idempotency: CREATE INDEX IF NOT EXISTS, so re-applying is a no-op.
+
+CREATE INDEX IF NOT EXISTS idx_mb_artist_name_lower_trgm
+    ON mb_artist USING GIN (lower(name) gin_trgm_ops);

--- a/schema/create_indexes.sql
+++ b/schema/create_indexes.sql
@@ -9,6 +9,11 @@ CREATE INDEX IF NOT EXISTS idx_mb_recording_credit ON mb_recording(artist_credit
 CREATE INDEX IF NOT EXISTS idx_mb_track_recording ON mb_track(recording);
 CREATE INDEX IF NOT EXISTS idx_mb_track_medium ON mb_track(medium);
 CREATE INDEX IF NOT EXISTS idx_mb_artist_name_lower ON mb_artist (lower(name));
+-- Trigram GIN index supports the `lower(name) % lower($1)` fuzzy search used by
+-- LML's external-cache fallback (lookup/external_search.py::_MB_ARTIST_FUZZY_SQL).
+-- Without it, `%` falls back to a seq-scan on the full filtered mb_artist table.
+CREATE INDEX IF NOT EXISTS idx_mb_artist_name_lower_trgm
+    ON mb_artist USING GIN (lower(name) gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS idx_mb_artist_area ON mb_artist (area);
 CREATE INDEX IF NOT EXISTS idx_mb_artist_alias_artist ON mb_artist_alias (artist);
 CREATE INDEX IF NOT EXISTS idx_mb_artist_alias_name_lower ON mb_artist_alias (lower(name));


### PR DESCRIPTION
## Summary

- Adds `idx_mb_artist_name_lower_trgm` (`GIN (lower(name) gin_trgm_ops)`) so LML's external-cache fallback no longer seq-scans `mb_artist` on every call.
- Updates both the runtime `schema/create_indexes.sql` (applied by `apply_schema()`) and ships a parallel sqlx migration `0002_mb_artist_name_trgm_index.sql` for the future sqlx-managed deploy path.
- Updates `CLAUDE.md` and `README.md` index counts (14 → 15).

## Motivation

PR [WXYC/library-metadata-lookup#185](https://github.com/WXYC/library-metadata-lookup/pull/185) added `_MB_ARTIST_FUZZY_SQL` in `lookup/external_search.py`:

```sql
SELECT gid AS id, name, similarity(lower(name), lower($1)) AS score
FROM mb_artist
WHERE lower(name) % lower($1)
ORDER BY score DESC
LIMIT $2
```

The `%` operator uses pg_trgm similarity. The existing `idx_mb_artist_name_lower` is a btree on `lower(name)` — it does not accelerate `%`. Without a GIN-trgm index, every fuzzy lookup seq-scans the full filtered `mb_artist`.

The 2026-04-27 lossy-mojibake matcher run (815 lossy values × 1 LML call each, MB leg hit on library-zero-hit cases) took ~25 minutes. Expected ~2-5 minutes with this index in place.

`pg_trgm` is already enabled by `0001_initial.sql` (`CREATE EXTENSION IF NOT EXISTS pg_trgm`), so no extension change is needed.

## Test plan

- [ ] After merge, apply to staging mb-cache (runtime path picks it up automatically on the next build, or manual `psql -c '\\i schema/create_indexes.sql'`).
- [ ] `EXPLAIN ANALYZE` on `_MB_ARTIST_FUZZY_SQL` confirms a Bitmap Index Scan on `idx_mb_artist_name_lower_trgm` (no Seq Scan on `mb_artist`).
- [ ] Re-run the lossy-mojibake matcher and document the new total wall time in a PR comment.
- [ ] Existing `tests/idempotency_test.rs` already covers the new index via its prefix-matched `idx_mb_%` snapshot — should pass unchanged.

## Out of scope

- Discogs-cache trigram indexes (separate audit).
- `mb_artist_alias` trigram indexes (#m1-6b).
- Wiring `sqlx migrate run` into the deploy path (tracked in WXYC/wxyc-etl#56).

Closes WXYC/library-metadata-lookup#190.
Refs WXYC/docs#6.