### PR TITLE
Pin wxyc-etl to crates.io 0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout wxyc-etl at expected relative path
-        run: git clone --depth 1 https://github.com/WXYC/wxyc-etl.git "$GITHUB_WORKSPACE/../../../wxyc-etl"
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -23,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout wxyc-etl at expected relative path
-        run: git clone --depth 1 https://github.com/WXYC/wxyc-etl.git "$GITHUB_WORKSPACE/../../../wxyc-etl"
       - uses: dtolnay/rust-toolchain@stable
       - name: Run tests (incl. local HTTP download tests)
         env:
@@ -49,8 +45,6 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout wxyc-etl at expected relative path
-        run: git clone --depth 1 https://github.com/WXYC/wxyc-etl.git "$GITHUB_WORKSPACE/../../../wxyc-etl"
       - uses: dtolnay/rust-toolchain@stable
       - name: Enable extensions
         run: |

--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -27,9 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout wxyc-etl at expected relative path
-        run: git clone --depth 1 https://github.com/WXYC/wxyc-etl.git "$GITHUB_WORKSPACE/../../../wxyc-etl"
-
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install parallel bzip2 decompressor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The full rebuild runs on GitHub Actions via `.github/workflows/rebuild-cache.yml
 
 ## Dependencies
 
-- **wxyc-etl** (path dependency) -- `text::normalize_artist_name` for name normalization, `schema::musicbrainz` for table constants, `logger::init` for Sentry + structured JSON logs.
+- **wxyc-etl** (`= "0.1.0"`, crates.io) -- `text::normalize_artist_name` for name normalization, `schema::musicbrainz` for table constants, `logger::init` for Sentry + structured JSON logs.
 - **postgres** -- Synchronous PostgreSQL client (matches wxyc-etl).
 - **rusqlite** -- SQLite for reading library.db.
 - **reqwest** (blocking) -- HTTP client for MusicBrainz dump downloads.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3317,6 +3317,8 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wxyc-etl"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e0a1f3339c2fb633a75b09d65fd022c4b1328f2965750097fa60c626930140"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "musicbrainz-cache"
 path = "src/main.rs"
 
 [dependencies]
-wxyc-etl = { path = "../../../wxyc-etl/wxyc-etl" }
+wxyc-etl = "0.1.0"
 postgres = "0.19"
 rusqlite = { version = "0.31", features = ["bundled"] }
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/README.md
+++ b/README.md
@@ -143,5 +143,5 @@ cargo fmt --check
 
 - Rust 1.75+
 - PostgreSQL 16 (via Docker Compose on port 5434)
-- [wxyc-etl](https://github.com/WXYC/wxyc-etl) crate (path dependency at `../../../wxyc-etl/wxyc-etl`)
+- [wxyc-etl](https://crates.io/crates/wxyc-etl) crate (resolved from crates.io; pinned to `0.1.0` in `Cargo.toml`)
 - Optional: lbzip2 or pbzip2 for faster archive extraction


### PR DESCRIPTION
## Summary

- Replace the `wxyc-etl` Cargo path-dep on `../../../wxyc-etl/wxyc-etl` with the published `wxyc-etl = "0.1.0"` from crates.io (exact pin per the project's 0.x lockstep policy).
- Drop the `Checkout wxyc-etl at expected relative path` step from every CI job (`lint`, `test`, `test-postgres`) and from the monthly `Rebuild Cache` workflow. Cargo now resolves wxyc-etl from the registry.
- Refresh `Cargo.lock` so wxyc-etl is sourced from `registry+https://github.com/rust-lang/crates.io-index`.
- Update `CLAUDE.md` and `README.md` references to reflect the new crates.io source.

Parent: WXYC/wxyc-etl#46

Closes #25

## Test plan

- [x] `cargo build` succeeds with `wxyc-etl` resolved from crates.io
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -A clippy::manual_is_multiple_of`
- [x] `cargo test` (unit + bin tests)
- [ ] CI green on this PR (lint, test, test-postgres)