### PR TITLE
WX-2.3.4: Migrate filter to wxyc-etl 0.2 to_match_form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The full rebuild runs on GitHub Actions via `.github/workflows/rebuild-cache.yml
 
 ## Dependencies
 
-- **wxyc-etl** (`= "0.1.0"`, crates.io) -- `text::normalize_artist_name` for name normalization, `schema::musicbrainz` for table constants, `logger::init` for Sentry + structured JSON logs.
+- **wxyc-etl** (`"0.2"`, crates.io) -- `text::to_match_form` (WX-2 Normalizer Charter, comparison form) for artist-name matching, `schema::musicbrainz` for table constants, `logger::init` for Sentry + structured JSON logs.
 - **postgres** -- Synchronous PostgreSQL client (matches wxyc-etl).
 - **rusqlite** -- SQLite for reading library.db.
 - **reqwest** (blocking) -- HTTP client for MusicBrainz dump downloads.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,14 +3324,15 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e0a1f3339c2fb633a75b09d65fd022c4b1328f2965750097fa60c626930140"
+checksum = "e1f6e6cda194702938a1b28276dc9df4d780c229ce491fb8c4e1fbdd3a4591f5"
 dependencies = [
  "anyhow",
  "clap",
  "crossbeam-channel",
  "csv",
+ "deunicode",
  "env_logger",
  "itoa",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "musicbrainz-cache"
 path = "src/main.rs"
 
 [dependencies]
-wxyc-etl = "0.1.0"
+wxyc-etl = "0.2"
 postgres = "0.19"
 rusqlite = { version = "0.31", features = ["bundled"] }
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use std::collections::HashSet;
 use std::io::Write;
 use std::path::Path;
-use wxyc_etl::text::normalize_artist_name;
+use wxyc_etl::text::to_match_form;
 
 /// Load normalized WXYC artist names from library.db.
 pub fn load_library_artists(library_db: &Path) -> anyhow::Result<HashSet<String>> {
@@ -16,7 +16,7 @@ pub fn load_library_artists(library_db: &Path) -> anyhow::Result<HashSet<String>
     for name in rows {
         let name = name?;
         if !name.is_empty() {
-            artists.insert(normalize_artist_name(&name));
+            artists.insert(to_match_form(&name));
         }
     }
 
@@ -40,7 +40,7 @@ pub fn find_matching_artist_ids(
     for row in client.query("SELECT id, name FROM mb_artist", &[])? {
         let id: i32 = row.get(0);
         let name: &str = row.get(1);
-        if library_artists.contains(&normalize_artist_name(name)) {
+        if library_artists.contains(&to_match_form(name)) {
             matching_ids.insert(id);
         }
         checked += 1;
@@ -60,7 +60,7 @@ pub fn find_matching_artist_ids(
     for row in client.query("SELECT artist, name FROM mb_artist_alias", &[])? {
         let artist_id: i32 = row.get(0);
         let name: &str = row.get(1);
-        if library_artists.contains(&normalize_artist_name(name)) {
+        if library_artists.contains(&to_match_form(name)) {
             matching_ids.insert(artist_id);
         }
     }

--- a/tests/filter_test.rs
+++ b/tests/filter_test.rs
@@ -21,8 +21,8 @@ fn db_url() -> String {
 
 #[test]
 fn test_normalize_matches_python() {
-    // Expected values derived from running the Python normalize() function.
-    // Python: unicodedata.normalize("NFKD", name) -> strip combining -> lower -> strip
+    // Expected values mirror the WX-2 Normalizer Charter `to_match_form`:
+    // NFKC -> casefold -> diacritic strip -> Cf strip -> Greek-sigma fold -> trim.
     let cases: &[(&str, &str)] = &[
         ("Autechre", "autechre"),
         ("Stereolab", "stereolab"),
@@ -38,10 +38,10 @@ fn test_normalize_matches_python() {
     ];
 
     for &(input, expected) in cases {
-        let result = wxyc_etl::text::normalize_artist_name(input);
+        let result = wxyc_etl::text::to_match_form(input);
         assert_eq!(
             result, expected,
-            "normalize('{}') = '{}', expected '{}'",
+            "to_match_form('{}') = '{}', expected '{}'",
             input, result, expected,
         );
     }


### PR DESCRIPTION
Closes #41.

## Summary

Migrates the MB-cache artist filter from the deprecated `wxyc_etl::text::normalize_artist_name` to the WX-2 Normalizer Charter `to_match_form` (comparison form), and bumps `wxyc-etl` to `0.2`.

## Callsites changed

| File | Line | Before | After |
|---|---|---|---|
| `Cargo.toml` | 16 | `wxyc-etl = "0.1.0"` | `wxyc-etl = "0.2"` |
| `src/filter.rs` | 5 | `use wxyc_etl::text::normalize_artist_name;` | `use wxyc_etl::text::to_match_form;` |
| `src/filter.rs` | 19 | `normalize_artist_name(&name)` | `to_match_form(&name)` |
| `src/filter.rs` | 43 | `normalize_artist_name(name)` (mb_artist match) | `to_match_form(name)` |
| `src/filter.rs` | 63 | `normalize_artist_name(name)` (mb_artist_alias match) | `to_match_form(name)` |
| `tests/filter_test.rs` | 41 | `wxyc_etl::text::normalize_artist_name(input)` | `wxyc_etl::text::to_match_form(input)` |

`CLAUDE.md` § Dependencies updated to reflect the new version + function name.

The ticket inventory listed a Python parity test at `tests/unit/test_filter_artists_rust.py:23`, but this repo is Rust-only (per `CLAUDE.md`) — no `tests/unit/` directory and no `pyproject.toml` exist on `main`. That callsite must live in a different repo; only the two Rust callsites apply here.

## Behavior diffs

`to_match_form` adds two transforms beyond `normalize_artist_name`:

1. **Cf-strip** — strips Unicode `Cf` (Format) characters (zero-width joiner U+200D, ZWNJ U+200C, bidi controls, etc.).
2. **Greek-sigma fold** — folds final sigma `ς` (U+03C2) to medial sigma `σ` (U+03C3).

Both the library-side set and the MB-side comparison use the same function, so matches remain internally consistent. The existing test cases (Latin diacritics, ASCII case, CJK, whitespace) produce identical output under both functions; `cargo test --test filter_test` passes without fixture changes.

The PG :5434 contents were filtered using the legacy normalizer. A regen may be warranted depending on downstream sensitivity — tracked separately in #42 (no auto-regen here, no data deletion).

## Acceptance criteria

- [x] `Cargo.toml` pins `wxyc-etl = "0.2"`.
- [x] `pyproject.toml` — N/A (no Python in this repo).
- [x] No remaining import of deprecated functions: `grep -rEn 'normalize_artist_name|batch_normalize|strip_diacritics|normalize_title' src/ tests/` returns empty.
- [x] `cargo test` green (lib + bin: 10 passed; integration unit cases: 9 passed; non-PG integration tests pass; PG-gated tests remain `#[ignore]`).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy -- -D warnings -A clippy::manual_is_multiple_of` clean.
- [x] Filter-behavior diff documented (above + #42).

## Local CI

- `cargo build`: clean
- `cargo test`: 10 + 2 + 9 + 2 + 0 + 0 + 10 passed; PG-gated tests ignored as expected
- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings -A clippy::manual_is_multiple_of`: clean