### PR TITLE
WX-3.B: strip U+0000 at TSV → PG COPY boundary

### DIFF
--- a/src/import.rs
+++ b/src/import.rs
@@ -207,10 +207,7 @@ pub fn import_table(
             if j > 0 {
                 buf.push(b'\t');
             }
-            // PostgreSQL TEXT rejects U+0000 (SQL standard). Strip at the
-            // write boundary per WXYC/docs#18: U+0000 in metadata is always
-            // corruption, never intent. Cheap and idempotent — the common
-            // case (no NUL) takes the borrowed branch with no allocation.
+            // strip NUL per WXYC/docs#18 — see strip_nul docstring.
             buf.extend_from_slice(strip_nul(val).as_bytes());
         }
         buf.push(b'\n');
@@ -265,4 +262,44 @@ pub fn import_all(client: &mut postgres::Client, data_dir: &Path) -> anyhow::Res
         elapsed.as_secs_f64()
     );
     Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_nul_borrowed_when_clean() {
+        let result = strip_nul("Stereolab");
+        assert_eq!(&*result, "Stereolab");
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn strip_nul_owned_when_nul_present() {
+        let result = strip_nul("a\0b");
+        assert_eq!(&*result, "ab");
+        assert!(matches!(result, Cow::Owned(_)));
+    }
+
+    #[test]
+    fn strip_nul_drops_all_nuls() {
+        assert_eq!(&*strip_nul("\0a\0b\0"), "ab");
+    }
+
+    #[test]
+    fn strip_nul_empty_passthrough() {
+        let result = strip_nul("");
+        assert_eq!(&*result, "");
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn strip_nul_idempotent() {
+        let once = strip_nul("a\0b\0c");
+        assert_eq!(&*once, "abc");
+        let twice = strip_nul(&once);
+        assert_eq!(&*twice, "abc");
+        assert!(matches!(twice, Cow::Borrowed(_)));
+    }
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,6 +1,21 @@
 use anyhow::Context;
+use std::borrow::Cow;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
+
+/// Strip U+0000 (NUL) bytes from a string before writing to a PG TEXT column.
+///
+/// PostgreSQL TEXT does not accept U+0000 (SQL standard). Per the org-wide
+/// policy in WXYC/docs#18, every PG TEXT write boundary strips NUL — U+0000
+/// in metadata is corruption, never intent. Returns `Cow::Borrowed` when no
+/// NUL is present so the common case avoids allocating.
+fn strip_nul(s: &str) -> Cow<'_, str> {
+    if s.contains('\0') {
+        Cow::Owned(s.replace('\0', ""))
+    } else {
+        Cow::Borrowed(s)
+    }
+}
 
 /// Mapping from a MusicBrainz dump file to our schema.
 ///
@@ -192,7 +207,11 @@ pub fn import_table(
             if j > 0 {
                 buf.push(b'\t');
             }
-            buf.extend_from_slice(val.as_bytes());
+            // PostgreSQL TEXT rejects U+0000 (SQL standard). Strip at the
+            // write boundary per WXYC/docs#18: U+0000 in metadata is always
+            // corruption, never intent. Cheap and idempotent — the common
+            // case (no NUL) takes the borrowed branch with no allocation.
+            buf.extend_from_slice(strip_nul(val).as_bytes());
         }
         buf.push(b'\n');
         row_count += 1;

--- a/tests/charset_torture.rs
+++ b/tests/charset_torture.rs
@@ -82,13 +82,15 @@ fn corpus_tsv_pg_roundtrip() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let tsv_path = tmp.path().join(TSV_FILENAME);
 
-    // Build a TSV. Skip entries that are known to break the TSV format itself
-    // (literal tab, NUL byte) so that TSV file is well-formed; those entries
-    // are checked against EXPECTED_FAILURES separately.
+    // Build a TSV. Skip entries that would break the TSV format itself
+    // (literal tab, newline) so the file is well-formed; those entries are
+    // checked against EXPECTED_FAILURES separately. NUL bytes are kept in the
+    // TSV — `import_table` strips U+0000 at the PG TEXT write boundary per
+    // WXYC/docs#18, so the round-trip read returns the stripped form.
     let mut tsv = String::new();
     let mut written: Vec<(usize, &str)> = Vec::new();
     for (id, _, input, _) in &entries {
-        if input.contains('\t') || input.contains('\n') || input.contains('\0') {
+        if input.contains('\t') || input.contains('\n') {
             continue;
         }
         tsv.push_str(&id.to_string());
@@ -143,7 +145,11 @@ fn corpus_tsv_pg_roundtrip() {
             }
         };
 
-        let passed = actual.as_deref() == Some(*input);
+        // Strip-at-boundary policy (WXYC/docs#18): U+0000 is stripped at the
+        // PG TEXT write boundary in import_table, so the round-trip read
+        // comes back as the NUL-stripped form.
+        let expected: String = input.replace('\0', "");
+        let passed = actual.as_deref() == Some(expected.as_str());
         match (passed, known) {
             (true, None) => {}
             (true, Some(_tag)) => {

--- a/tests/charset_torture.rs
+++ b/tests/charset_torture.rs
@@ -41,11 +41,6 @@ fn expected_failures() -> HashMap<&'static str, &'static str> {
         "tab\there",
         "[mbc:tsv-tab-byte] literal tab is the TSV field separator",
     );
-    // U+0000 is invalid in PG TEXT (SQL standard).
-    m.insert(
-        "null\x00byte",
-        "[mbc:pg-null-byte] PostgreSQL TEXT rejects U+0000 (SQL standard)",
-    );
     // PG COPY ... WITH (FORMAT text) treats backslash as an escape character.
     // The MusicBrainz dumps escape backslashes upstream; if a future MB schema
     // ships unescaped TSV, this test will start failing as an unexpected pass.


### PR DESCRIPTION
Closes #39 — implements the WXYC/docs#18 ratified policy (option 1, strip at boundary) for the TSV → PostgreSQL COPY path in `musicbrainz-cache`.

## Change

PostgreSQL TEXT rejects U+0000 (SQL standard). The WX-1 charset-torture corpus's `quoting:null\x00byte` entry exercises this; the round-trip test was tagged as a strict xfail (`[mbc:pg-null-byte]`). Per WXYC/docs#18 the policy is: **strip U+0000 at every PG TEXT write boundary** — U+0000 in metadata is always corruption, never intent.

## Files / callsites

- `src/import.rs` — added `strip_nul(&str) -> Cow<'_, str>` helper (returns `Borrowed` when no NUL, so the common case never allocates). Applied once per field at the COPY-buffer write site inside `import_table()`'s row loop, immediately before `buf.extend_from_slice(...)`.
- `tests/charset_torture.rs` — removed the `null\x00byte` → `[mbc:pg-null-byte]` entry from `expected_failures()`. The strict-xfail harness's "unexpected pass" detector would have failed loudly otherwise.

## Behavior diff

- Before: `cargo test -- --ignored` ran charset_torture and recorded `null\x00byte` as a known PG-TEXT failure (correct xfail).
- After: the field's NUL is stripped before COPY, the write succeeds, the round-trip read comes back as the NUL-stripped form, and the test passes without an xfail entry.

## AC checklist

- [x] `import_table()` filters U+0000 from each line's parts before pushing to the COPY buffer (per WXYC/docs#18 option-1)
- [x] `[mbc:pg-null-byte]` removed from `tests/charset_torture.rs:expected_failures()` in the same commit
- [x] No data regen, no shims — defensive boundary fix
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings -A clippy::manual_is_multiple_of` clean locally
- [x] `cargo test` (unit) clean locally; PG-gated charset_torture exercised by the `test-postgres` CI job (no local Docker available)

## Notes

MusicBrainz's own dumps don't carry NUL bytes in production — this is defensive. The same pattern lands across all PG-writing repos under WX-3 sub-issues.