### PR TITLE
deps: bump wxyc-etl 0.2 → 0.3.0 (E3 step 5c)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The full rebuild runs on GitHub Actions via `.github/workflows/rebuild-cache.yml
 
 ## Dependencies
 
-- **wxyc-etl** (`"0.2"`, crates.io) -- `text::to_match_form` (WX-2 Normalizer Charter, comparison form) for artist-name matching, `schema::musicbrainz` for table constants, `logger::init` for Sentry + structured JSON logs.
+- **wxyc-etl** (`"0.3.0"`, crates.io) -- `text::to_match_form` (WX-2 Normalizer Charter, comparison form) for artist-name matching, `schema::musicbrainz` for table constants, `logger::init` for Sentry + structured JSON logs.
 - **postgres** -- Synchronous PostgreSQL client (matches wxyc-etl).
 - **rusqlite** -- SQLite for reading library.db.
 - **reqwest** (blocking) -- HTTP client for MusicBrainz dump downloads.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,9 +3324,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f6e6cda194702938a1b28276dc9df4d780c229ce491fb8c4e1fbdd3a4591f5"
+checksum = "e9f4f32d293cb6ab6d935ebfb343dd0581f0e2592c69e85612c78c05a171339b"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "musicbrainz-cache"
 path = "src/main.rs"
 
 [dependencies]
-wxyc-etl = "0.2"
+wxyc-etl = "0.3.0"
 postgres = "0.19"
 rusqlite = { version = "0.31", features = ["bundled"] }
 reqwest = { version = "0.12", features = ["blocking"] }


### PR DESCRIPTION
## Summary
- Bumps `wxyc-etl` pin from `0.2` to `0.3.0`, pulling in the cross-cache-identity normalizers (`to_identity_match_form` family) per [library-hook-canonicalization-plan §3.3.1 step 5](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md).
- Pure pin bump — the deprecated `normalize_artist_name` was already removed in b595d00 (filter migrated to `to_match_form`). Also updates the version reference in CLAUDE.md.

## Test plan
- [x] `cargo build --workspace` succeeds
- [x] `cargo test --workspace --lib` passes
- [x] `cargo test --workspace --tests` passes (PG-gated tests skip without `TEST_DATABASE_URL`)
- [x] No `wxyc_etl::text::normalize_artist_name` callers (already migrated)

Closes #45
Refs WXYC/wxyc-etl#73 (E3 step 5c)