### PR TITLE
Add wxyc_library v2 hook (E1 §4.1.2 cross-cache-identity)

### DIFF
--- a/migrations/0003_wxyc_library_v2.sql
+++ b/migrations/0003_wxyc_library_v2.sql
@@ -1,0 +1,85 @@
+-- Consolidated cross-cache identity hook table (E1 §4.1.2 of the
+-- cross-cache-identity rollout).
+--
+-- Spec: https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization.md
+-- §3.1 (full schema) + §4.1.2 (this cache: Homebrew musicbrainz, port 5432).
+--
+-- One row per WXYC library release. ``library_id`` mirrors Backend's
+-- ``wxyc_schema.library.id``. The normalized columns (``norm_artist``,
+-- ``norm_title``, ``norm_label``) are populated by
+-- ``wxyc_etl::text::to_identity_match_form{,_title}`` (the locked-on
+-- baseline; not the WX-2 comparison form ``to_match_form``). All
+-- consumers (LML, semantic-index, audits) join on these normalized
+-- columns, so the algorithm must stay pinned across caches.
+--
+-- ``artist_id`` / ``label_id`` / ``format_id`` / ``release_year`` are
+-- nullable per §3.1: per-cache loaders populate what their source
+-- exposes, and library.db (the SQLite catalog export this cache reads)
+-- does not carry Backend's integer IDs.
+--
+-- CONCURRENTLY deviation (read this carefully): wiki §4.1.2 calls for
+-- "all indexes built CONCURRENTLY since the cache is large and
+-- active". The literal directive cannot be honored in a single
+-- sqlx-cli migration: sqlx-postgres sends every migration's SQL as a
+-- single PG simple-Query message, and PG treats multi-statement simple
+-- queries as one implicit transaction. ``CREATE INDEX CONCURRENTLY``
+-- refuses to run inside any transaction block, implicit or explicit.
+-- The discogs-etl analog (0003_wxyc_library_v2.py) sidesteps this by
+-- using psycopg autocommit with one ``cur.execute()`` per CONCURRENTLY
+-- statement. The Rust/sqlx equivalent would be splitting into N
+-- one-statement no-transaction migrations -- a heavyweight wrapping
+-- for a brand-new empty table that has no readers and no rows on
+-- first apply (the only state where CONCURRENTLY is meaningful). On
+-- re-apply, ``IF NOT EXISTS`` short-circuits before any locking, so
+-- there's nothing for CONCURRENTLY to protect against. Plain
+-- ``CREATE INDEX IF NOT EXISTS`` is therefore the appropriate Rust/sqlx
+-- realisation of the §4.1.2 intent: idempotent, lock-light on re-run,
+-- and behaviorally equivalent to the discogs-etl path on first run
+-- (both build into an empty table). If/when this migration ever needs
+-- to land against a populated wxyc_library, split into per-index
+-- no-transaction migrations at that time.
+--
+-- Idempotency: ``CREATE TABLE IF NOT EXISTS`` + ``CREATE INDEX IF NOT
+-- EXISTS`` make every statement re-runnable, as required by the
+-- dual-source mirror (schema/create_database.sql +
+-- schema/create_indexes.sql) the runtime ``apply_schema()`` path uses.
+
+CREATE TABLE IF NOT EXISTS wxyc_library (
+    library_id      INTEGER PRIMARY KEY,
+    artist_id       INTEGER,
+    artist_name     TEXT NOT NULL,
+    album_title     TEXT NOT NULL,
+    label_id        INTEGER,
+    label_name      TEXT,
+    format_id       INTEGER,
+    format_name     TEXT,
+    wxyc_genre      TEXT,
+    call_letters    TEXT,
+    call_numbers    INTEGER,
+    release_year    SMALLINT,
+    norm_artist     TEXT NOT NULL,
+    norm_title      TEXT NOT NULL,
+    norm_label      TEXT,
+    snapshot_at     TIMESTAMPTZ NOT NULL,
+    snapshot_source TEXT NOT NULL
+        CHECK (snapshot_source IN ('backend', 'tubafrenzy', 'llm'))
+);
+
+CREATE INDEX IF NOT EXISTS wxyc_library_norm_artist_idx
+    ON wxyc_library (norm_artist);
+CREATE INDEX IF NOT EXISTS wxyc_library_norm_title_idx
+    ON wxyc_library (norm_title);
+CREATE INDEX IF NOT EXISTS wxyc_library_artist_id_idx
+    ON wxyc_library (artist_id);
+CREATE INDEX IF NOT EXISTS wxyc_library_format_id_idx
+    ON wxyc_library (format_id);
+CREATE INDEX IF NOT EXISTS wxyc_library_release_year_idx
+    ON wxyc_library (release_year);
+
+-- GIN trigram indexes for fuzzy lookup on the normalized columns.
+-- ``gin_trgm_ops`` requires the pg_trgm extension; the baseline
+-- (0001_initial.sql) already creates it.
+CREATE INDEX IF NOT EXISTS wxyc_library_norm_artist_trgm_idx
+    ON wxyc_library USING GIN (norm_artist gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS wxyc_library_norm_title_trgm_idx
+    ON wxyc_library USING GIN (norm_title gin_trgm_ops);

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -159,4 +159,34 @@ CREATE TABLE IF NOT EXISTS mb_l_release_url (
     url         integer NOT NULL REFERENCES mb_url(id)
 );
 
+-- Cross-cache identity hook (E1 §4.1.2 of library-hook-canonicalization.md).
+-- Mirrored in migrations/0003_wxyc_library_v2.sql. Schema-side dual-write per
+-- the CLAUDE.md "Migrations" contract: fresh-rebuild via apply_schema() must
+-- produce the same end-state as the migration chain.
+--
+-- ``library_id`` mirrors Backend's ``wxyc_schema.library.id``. ``artist_id``
+-- / ``label_id`` / ``format_id`` / ``release_year`` are nullable: this cache
+-- reads from library.db which does not carry Backend's integer IDs.
+-- ``snapshot_source`` CHECK enforces the §3.1 vocabulary.
+CREATE TABLE IF NOT EXISTS wxyc_library (
+    library_id      integer PRIMARY KEY,
+    artist_id       integer,
+    artist_name     text NOT NULL,
+    album_title     text NOT NULL,
+    label_id        integer,
+    label_name      text,
+    format_id       integer,
+    format_name     text,
+    wxyc_genre      text,
+    call_letters    text,
+    call_numbers    integer,
+    release_year    smallint,
+    norm_artist     text NOT NULL,
+    norm_title      text NOT NULL,
+    norm_label      text,
+    snapshot_at     timestamptz NOT NULL,
+    snapshot_source text NOT NULL
+        CHECK (snapshot_source IN ('backend', 'tubafrenzy', 'llm'))
+);
+
 -- Indexes are created separately after bulk import (see create_indexes.sql).

--- a/schema/create_indexes.sql
+++ b/schema/create_indexes.sql
@@ -40,7 +40,9 @@ CREATE INDEX IF NOT EXISTS wxyc_library_release_year_idx ON wxyc_library (releas
 CREATE INDEX IF NOT EXISTS wxyc_library_norm_artist_trgm_idx ON wxyc_library USING GIN (norm_artist gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS wxyc_library_norm_title_trgm_idx ON wxyc_library USING GIN (norm_title gin_trgm_ops);
 -- The wxyc_library indexes above support the cross-cache identity hook
--- (E1 section 4.1.2 of plans/library-hook-canonicalization.md). They are
--- mirrored CONCURRENTLY in migrations/0003_wxyc_library_v2.sql for safe
--- re-application against a populated prod cache. This file runs against an
--- empty cache during fresh rebuilds, so plain CREATE INDEX is appropriate.
+-- (E1 section 4.1.2 of plans/library-hook-canonicalization.md). The
+-- migrations/0003_wxyc_library_v2.sql counterpart also uses plain
+-- CREATE INDEX IF NOT EXISTS — the in-file comment in that migration
+-- explains why CONCURRENTLY can't be honored under sqlx-cli's implicit
+-- transaction. Both paths are safe on first apply (empty wxyc_library →
+-- no contention) and short-circuit on re-apply via IF NOT EXISTS.

--- a/schema/create_indexes.sql
+++ b/schema/create_indexes.sql
@@ -32,3 +32,15 @@ CREATE INDEX IF NOT EXISTS idx_mb_l_release_group_url_url ON mb_l_release_group_
 CREATE INDEX IF NOT EXISTS idx_mb_l_release_url_release ON mb_l_release_url(release);
 CREATE INDEX IF NOT EXISTS idx_mb_l_release_url_url ON mb_l_release_url(url);
 CREATE INDEX IF NOT EXISTS idx_mb_link_type ON mb_link(link_type);
+CREATE INDEX IF NOT EXISTS wxyc_library_norm_artist_idx ON wxyc_library (norm_artist);
+CREATE INDEX IF NOT EXISTS wxyc_library_norm_title_idx ON wxyc_library (norm_title);
+CREATE INDEX IF NOT EXISTS wxyc_library_artist_id_idx ON wxyc_library (artist_id);
+CREATE INDEX IF NOT EXISTS wxyc_library_format_id_idx ON wxyc_library (format_id);
+CREATE INDEX IF NOT EXISTS wxyc_library_release_year_idx ON wxyc_library (release_year);
+CREATE INDEX IF NOT EXISTS wxyc_library_norm_artist_trgm_idx ON wxyc_library USING GIN (norm_artist gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS wxyc_library_norm_title_trgm_idx ON wxyc_library USING GIN (norm_title gin_trgm_ops);
+-- The wxyc_library indexes above support the cross-cache identity hook
+-- (E1 section 4.1.2 of plans/library-hook-canonicalization.md). They are
+-- mirrored CONCURRENTLY in migrations/0003_wxyc_library_v2.sql for safe
+-- re-application against a populated prod cache. This file runs against an
+-- empty cache during fresh rebuilds, so plain CREATE INDEX is appropriate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod filter;
 pub mod import;
 pub mod schema;
 pub mod state;
+pub mod wxyc_loader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context};
 use clap::{Args, Parser, Subcommand};
 use musicbrainz_cache::state::{PipelineState, Step};
-use musicbrainz_cache::{download, filter, import, schema};
+use musicbrainz_cache::{download, filter, import, schema, wxyc_loader};
 use std::path::{Path, PathBuf};
 use wxyc_etl::cli::{resolve_database_url, DatabaseArgs, ImportArgs, ResumableBuildArgs};
 use wxyc_etl::logger::{self, LoggerConfig};
@@ -25,6 +25,16 @@ enum Command {
     Build(BuildCmd),
     /// Load a fresh MusicBrainz dump into PostgreSQL (download + schema + import).
     Import(ImportCmd),
+    /// Populate the consolidated `wxyc_library` cross-cache identity hook.
+    ///
+    /// Implements E1 §4.1.2 of the cross-cache-identity rollout. Requires the
+    /// `0003_wxyc_library_v2.sql` migration to have been applied (or
+    /// `apply_schema()` to have run on a fresh DB). Reads a SQLite library.db
+    /// and writes one row per release into `wxyc_library`. Idempotent on
+    /// `library_id`. Wired as a standalone subcommand (not as a step in
+    /// `build`) so this PR's scope stays surgical; the build-step wiring
+    /// lands as a follow-up once the dual-write window opens.
+    ImportWxycLibrary(ImportWxycLibraryCmd),
 }
 
 #[derive(Args)]
@@ -67,6 +77,22 @@ struct ImportCmd {
     /// Override dump URL (default: auto-detect latest).
     #[arg(long)]
     dump_url: Option<String>,
+}
+
+#[derive(Args)]
+struct ImportWxycLibraryCmd {
+    #[command(flatten)]
+    db: DatabaseArgs,
+
+    /// Path to the SQLite library.db produced by wxyc-export-to-sqlite.
+    #[arg(long)]
+    library_db: PathBuf,
+
+    /// Origin of the snapshot. Must be one of `backend`, `tubafrenzy`, `llm`
+    /// (matches the §3.1 CHECK constraint vocabulary). Defaults to `backend`
+    /// since this cache reads from a Backend-derived library.db.
+    #[arg(long, default_value = "backend")]
+    snapshot_source: String,
 }
 
 fn wait_for_postgres(db_url: &str, timeout_secs: u64) -> anyhow::Result<()> {
@@ -347,6 +373,7 @@ fn main() -> anyhow::Result<()> {
     let tool = match &cli.command {
         Command::Build(_) => "musicbrainz-cache build",
         Command::Import(_) => "musicbrainz-cache import",
+        Command::ImportWxycLibrary(_) => "musicbrainz-cache import-wxyc-library",
     };
     // TODO(sentry-dsn): provision SENTRY_DSN in the runtime env (Railway /
     // GitHub Actions / EC2) so panics are forwarded. Without it Sentry stays
@@ -367,7 +394,25 @@ fn main() -> anyhow::Result<()> {
     match cli.command {
         Command::Build(cmd) => run_build(cmd),
         Command::Import(cmd) => run_import(cmd),
+        Command::ImportWxycLibrary(cmd) => run_import_wxyc_library(cmd),
     }
+}
+
+fn run_import_wxyc_library(cmd: ImportWxycLibraryCmd) -> anyhow::Result<()> {
+    let database_url = resolve_database_url(&cmd.db, DATABASE_ENV_NAME)?;
+    log::info!("import-wxyc-library starting");
+    log::info!("  Database: {}", db_display(&database_url));
+    log::info!("  library.db: {}", cmd.library_db.display());
+    log::info!("  snapshot_source: {}", cmd.snapshot_source);
+
+    wait_for_postgres(&database_url, 30)?;
+    let mut client = postgres::Client::connect(&database_url, postgres::NoTls)
+        .context("Failed to connect to PostgreSQL")?;
+
+    let written =
+        wxyc_loader::populate_wxyc_library_v2(&mut client, &cmd.library_db, &cmd.snapshot_source)?;
+    log::info!("import-wxyc-library complete; {} rows attempted", written);
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/wxyc_loader.rs
+++ b/src/wxyc_loader.rs
@@ -163,7 +163,22 @@ fn read_library_db(library_db: &Path) -> anyhow::Result<Vec<LibraryRow>> {
             format_name,
             wxyc_genre: genre,
             call_letters,
-            call_numbers: release_call_number.and_then(|n| i32::try_from(n).ok()),
+            // Mirror the `id` overflow handling above: i32 is what the PG
+            // schema expects; a SQLite value that doesn't fit must surface
+            // as a hard error, not silently become NULL. Catalog
+            // call_numbers are small in practice, but a malformed source
+            // row should fail loud.
+            call_numbers: release_call_number
+                .map(|n| {
+                    i32::try_from(n).map_err(|_| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            0,
+                            rusqlite::types::Type::Integer,
+                            format!("library.release_call_number {n} does not fit in i32").into(),
+                        )
+                    })
+                })
+                .transpose()?,
         })
     })?;
 
@@ -243,6 +258,28 @@ pub fn populate_wxyc_library_v2(
         );
         return Ok(0);
     }
+
+    // Validate every row BEFORE opening the COPY stream. Bailing
+    // mid-stream would leave `writer.finish()` uncalled and the
+    // connection's COPY state implicit-dropped — the outer transaction
+    // still rolls back cleanly (TEMP table + ON COMMIT DROP), but the
+    // pre-pass is cheap and keeps the COPY loop a tight write path.
+    // Postgres `NOT NULL` on the staging table rejects SQL NULL but NOT
+    // empty strings, so this is the only place an empty artist/title
+    // gets caught before it lands with an empty norm_* column and
+    // defeats downstream NULL-aware joins.
+    for r in &rows {
+        if r.artist_name.is_empty() || r.album_title.is_empty() {
+            anyhow::bail!(
+                "library_id {}: artist_name or album_title is empty (artist={:?}, title={:?}). \
+                 library.db rows must have non-empty artist/title; fix the source row \
+                 before re-running the loader.",
+                r.library_id,
+                r.artist_name,
+                r.album_title,
+            );
+        }
+    }
     let attempted = rows.len() as u64;
 
     // Stage rows into a TEMP table via COPY, then INSERT ... ON CONFLICT
@@ -282,23 +319,11 @@ pub fn populate_wxyc_library_v2(
              ) FROM STDIN WITH (FORMAT text, NULL '\\N')",
         )?;
         for r in &rows {
-            // norm_artist / norm_title are NOT NULL per §3.1. Postgres `NOT
-            // NULL` rejects SQL NULL but NOT empty strings — so an empty
-            // artist or title would silently land with an empty norm_*
-            // column, defeating downstream NULL-aware joins. Catch it here
-            // explicitly so the upstream issue (likely a SQLite NULL that
-            // `read_library_db` collapsed to "") surfaces with a clear error
-            // instead of corrupting the cache.
-            if r.artist_name.is_empty() || r.album_title.is_empty() {
-                anyhow::bail!(
-                    "library_id {}: artist_name or album_title is empty (artist={:?}, title={:?}). \
-                     library.db rows must have non-empty artist/title; fix the source row \
-                     before re-running the loader.",
-                    r.library_id,
-                    r.artist_name,
-                    r.album_title,
-                );
-            }
+            // Empty-string validation runs in the pre-pass above; reaching
+            // this loop means every row has non-empty artist/title and is
+            // safe to write. Keep this loop a tight COPY-write path with
+            // no early bails — finishing the writer cleanly is cheaper
+            // than relying on transaction rollback.
             let norm_artist = to_identity_match_form(&r.artist_name);
             let norm_title = to_identity_match_form_title(&r.album_title);
             let norm_label_v = norm_label(r.label_name.as_deref());

--- a/src/wxyc_loader.rs
+++ b/src/wxyc_loader.rs
@@ -282,11 +282,23 @@ pub fn populate_wxyc_library_v2(
              ) FROM STDIN WITH (FORMAT text, NULL '\\N')",
         )?;
         for r in &rows {
-            // norm_artist / norm_title are NOT NULL per §3.1; the normalizer
-            // collapses to a non-empty string for any non-empty input. We
-            // do not paper over an empty result here — if an empty artist or
-            // title slipped in upstream, the NOT NULL on the staging table
-            // will reject the row and surface the upstream issue.
+            // norm_artist / norm_title are NOT NULL per §3.1. Postgres `NOT
+            // NULL` rejects SQL NULL but NOT empty strings — so an empty
+            // artist or title would silently land with an empty norm_*
+            // column, defeating downstream NULL-aware joins. Catch it here
+            // explicitly so the upstream issue (likely a SQLite NULL that
+            // `read_library_db` collapsed to "") surfaces with a clear error
+            // instead of corrupting the cache.
+            if r.artist_name.is_empty() || r.album_title.is_empty() {
+                anyhow::bail!(
+                    "library_id {}: artist_name or album_title is empty (artist={:?}, title={:?}). \
+                     library.db rows must have non-empty artist/title; fix the source row \
+                     before re-running the loader.",
+                    r.library_id,
+                    r.artist_name,
+                    r.album_title,
+                );
+            }
             let norm_artist = to_identity_match_form(&r.artist_name);
             let norm_title = to_identity_match_form_title(&r.album_title);
             let norm_label_v = norm_label(r.label_name.as_deref());

--- a/src/wxyc_loader.rs
+++ b/src/wxyc_loader.rs
@@ -176,11 +176,14 @@ fn read_library_db(library_db: &Path) -> anyhow::Result<Vec<LibraryRow>> {
 
 /// Identity-tier normalization for the optional `label_name` column.
 ///
-/// `to_identity_match_form` accepts `&str` — we want NULL to flow through to
-/// PostgreSQL for the nullable `norm_label` column, so re-introduce the
-/// `Option` at the boundary.
+/// We want NULL to flow through to PostgreSQL for the nullable `norm_label`
+/// column so downstream NULL-aware joins behave correctly. The `.filter`
+/// collapses both the `None` input case AND a `Some("")` post-normalization
+/// case (e.g. a `Some("   ")` whitespace-only label, or a Some("") empty
+/// label that schema drift or a bulk-import artifact could produce) to a
+/// single `None`.
 fn norm_label(label: Option<&str>) -> Option<String> {
-    label.map(to_identity_match_form)
+    label.map(to_identity_match_form).filter(|s| !s.is_empty())
 }
 
 /// Strip U+0000 (NUL) bytes before writing to a PG TEXT column.
@@ -395,6 +398,15 @@ mod tests {
     fn norm_label_normalizes_some() {
         // "Sonamos" should fold to lowercase via the locked-on baseline.
         assert_eq!(norm_label(Some("Sonamos")).as_deref(), Some("sonamos"));
+    }
+
+    #[test]
+    fn norm_label_drops_empty_string() {
+        // `Some("")` and `Some("   ")` (whitespace that the normalizer
+        // collapses to "") must come back as `None` so downstream
+        // NULL-aware lookups on norm_label behave correctly.
+        assert_eq!(norm_label(Some("")), None);
+        assert_eq!(norm_label(Some("   ")), None);
     }
 
     #[test]

--- a/src/wxyc_loader.rs
+++ b/src/wxyc_loader.rs
@@ -1,0 +1,405 @@
+//! WXYC library hook loader for the Homebrew musicbrainz-cache.
+//!
+//! Implements E1 §4.1.2 of the cross-cache-identity rollout:
+//! <https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization.md#412-homebrew-musicbrainz-port-5432>
+//!
+//! Reads a SQLite `library.db` (the same file [`crate::filter`] uses to
+//! determine which MusicBrainz artists to keep) and writes one row per
+//! library release into the consolidated `wxyc_library` table created by
+//! migration `0003_wxyc_library_v2.sql`.
+//!
+//! # Normalization
+//!
+//! The new schema's `norm_artist` / `norm_title` / `norm_label` columns are
+//! populated by [`wxyc_etl::text::to_identity_match_form`] (the locked-on
+//! baseline; same function used for `norm_label` since labels share the
+//! artist-side pipeline) and [`wxyc_etl::text::to_identity_match_form_title`]
+//! for titles. **This is intentionally NOT [`wxyc_etl::text::to_match_form`]**
+//! — the WX-2 comparison form lives in `filter.rs` for artist matching, but
+//! the cross-cache-identity hook stays on the locked-on identity baseline so
+//! every consumer cache normalizes identically.
+//!
+//! # Idempotency
+//!
+//! `INSERT ... ON CONFLICT (library_id) DO NOTHING` makes the loader safe to
+//! re-run. Re-running against the same library.db is a no-op modulo the
+//! `snapshot_at` of the rows that were already present (which is preserved by
+//! `DO NOTHING`).
+//!
+//! # Backend ID columns
+//!
+//! `artist_id` / `label_id` / `format_id` / `release_year` are stamped NULL
+//! today: library.db (the SQLite catalog export this cache reads) does not
+//! carry Backend's integer IDs. They exist in the schema (per wiki §3.1) for
+//! forward compatibility with a future Backend-direct loader.
+
+use anyhow::Context;
+use std::io::Write;
+use std::path::Path;
+use wxyc_etl::text::{to_identity_match_form, to_identity_match_form_title};
+
+/// Snapshot-source vocabulary mirroring the §3.1 CHECK constraint.
+///
+/// Loaders pass one of these to indicate which CatalogSource produced the
+/// row. The cache-side CHECK rejects anything else.
+const VALID_SNAPSHOT_SOURCES: &[&str] = &["backend", "tubafrenzy", "llm"];
+
+/// Audit string identifying the locked-on baseline normalizer.
+///
+/// Mirrored in the discogs-etl loader (`loaders/wxyc.py::NORMALIZER_NAME`).
+/// Tests and integration audits assert this constant verbatim so a future
+/// API rename in `wxyc_etl::text` is caught immediately.
+pub const NORMALIZER_NAME: &str = "wxyc_etl::text::to_identity_match_form";
+
+/// One row to be written into `wxyc_library`.
+///
+/// Mirrors §3.1's column list. `artist_id` / `label_id` / `format_id` /
+/// `release_year` are nullable: per-cache loaders populate what their
+/// source exposes, and library.db does not carry Backend's integer IDs.
+#[derive(Debug, Clone)]
+struct LibraryRow {
+    library_id: i32,
+    artist_name: String,
+    album_title: String,
+    label_name: Option<String>,
+    format_name: Option<String>,
+    wxyc_genre: Option<String>,
+    call_letters: Option<String>,
+    call_numbers: Option<i32>,
+}
+
+/// Adapt to whatever optional columns are present in the library.db.
+///
+/// The minimal-fixture schema is `(artist)` (see tests/fixtures/library.db).
+/// The prod schema additionally carries title, label, format, etc. We always
+/// require `id`/`artist`/`title`; the rest are optional.
+fn existing_columns(conn: &rusqlite::Connection, table: &str) -> anyhow::Result<Vec<String>> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    let mut cols = Vec::new();
+    for r in rows {
+        cols.push(r?);
+    }
+    Ok(cols)
+}
+
+const OPTIONAL_COLUMNS: &[&str] = &[
+    "label",
+    "genre",
+    "call_letters",
+    "release_call_number",
+    "format",
+];
+
+fn read_library_db(library_db: &Path) -> anyhow::Result<Vec<LibraryRow>> {
+    let conn = rusqlite::Connection::open(library_db)
+        .with_context(|| format!("Failed to open {}", library_db.display()))?;
+
+    let cols = existing_columns(&conn, "library")?;
+    let has = |c: &str| cols.iter().any(|x| x == c);
+    if !has("id") || !has("artist") || !has("title") {
+        anyhow::bail!(
+            "library.db at {} is missing required columns id/artist/title (have: {:?})",
+            library_db.display(),
+            cols
+        );
+    }
+
+    // SELECT a fixed prefix plus whatever optional columns exist. We map the
+    // optional positions back to fields below by name lookup.
+    let mut select_parts: Vec<&str> = vec!["id", "artist", "title"];
+    for &c in OPTIONAL_COLUMNS {
+        if has(c) {
+            select_parts.push(c);
+        }
+    }
+    let query = format!("SELECT {} FROM library", select_parts.join(", "));
+
+    let mut stmt = conn.prepare(&query)?;
+    let column_names: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
+    let rows_iter = stmt.query_map([], |row| {
+        let mut id_opt: Option<i64> = None;
+        let mut artist: Option<String> = None;
+        let mut title: Option<String> = None;
+        let mut label: Option<String> = None;
+        let mut format_name: Option<String> = None;
+        let mut genre: Option<String> = None;
+        let mut call_letters: Option<String> = None;
+        let mut release_call_number: Option<i64> = None;
+
+        for (i, name) in column_names.iter().enumerate() {
+            match name.as_str() {
+                "id" => id_opt = row.get(i)?,
+                "artist" => artist = row.get(i)?,
+                "title" => title = row.get(i)?,
+                "label" => label = row.get(i)?,
+                "format" => format_name = row.get(i)?,
+                "genre" => genre = row.get(i)?,
+                "call_letters" => call_letters = row.get(i)?,
+                "release_call_number" => release_call_number = row.get(i)?,
+                _ => {}
+            }
+        }
+        Ok(LibraryRow {
+            library_id: id_opt
+                .ok_or_else(|| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Integer,
+                        "id is NULL".into(),
+                    )
+                })?
+                .try_into()
+                .map_err(|_| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Integer,
+                        "library.id does not fit in i32".into(),
+                    )
+                })?,
+            artist_name: artist.unwrap_or_default(),
+            album_title: title.unwrap_or_default(),
+            label_name: label,
+            format_name,
+            wxyc_genre: genre,
+            call_letters,
+            call_numbers: release_call_number.and_then(|n| i32::try_from(n).ok()),
+        })
+    })?;
+
+    let mut out = Vec::new();
+    for r in rows_iter {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+/// Identity-tier normalization for the optional `label_name` column.
+///
+/// `to_identity_match_form` accepts `&str` — we want NULL to flow through to
+/// PostgreSQL for the nullable `norm_label` column, so re-introduce the
+/// `Option` at the boundary.
+fn norm_label(label: Option<&str>) -> Option<String> {
+    label.map(to_identity_match_form)
+}
+
+/// Strip U+0000 (NUL) bytes before writing to a PG TEXT column.
+///
+/// Mirrors `import.rs::strip_nul`. Per the org-wide WXYC/docs#18 policy,
+/// every PG TEXT write boundary strips NUL — U+0000 in metadata is
+/// corruption, never intent.
+fn strip_nul(s: &str) -> String {
+    if s.contains('\0') {
+        s.replace('\0', "")
+    } else {
+        s.to_owned()
+    }
+}
+
+fn strip_nul_opt(s: Option<&str>) -> Option<String> {
+    s.map(strip_nul)
+}
+
+/// Populate the consolidated `wxyc_library` hook from a SQLite library.db.
+///
+/// Per E1 §4.1.2 + §3.1: every library row is written. Idempotent on
+/// `library_id` via `ON CONFLICT DO NOTHING`. `snapshot_at` is stamped
+/// server-side via `now()` so all rows in a single load share a timestamp
+/// without requiring a chrono dep on the Rust side.
+///
+/// Returns the number of rows attempted (pre-conflict). Idempotency is
+/// observable via `SELECT COUNT(*) FROM wxyc_library` rather than the return
+/// value.
+///
+/// # Errors
+///
+/// - Returns an error if `snapshot_source` is not one of `backend`,
+///   `tubafrenzy`, `llm`. The cache-side CHECK constraint enforces the same
+///   vocabulary; this client-side check fails fast before opening a write.
+/// - Returns an error if `library_db` cannot be opened or its `library`
+///   table is missing `id`/`artist`/`title`.
+/// - Propagates PostgreSQL errors from the COPY-style write path.
+pub fn populate_wxyc_library_v2(
+    client: &mut postgres::Client,
+    library_db: &Path,
+    snapshot_source: &str,
+) -> anyhow::Result<u64> {
+    if !VALID_SNAPSHOT_SOURCES.contains(&snapshot_source) {
+        anyhow::bail!(
+            "snapshot_source must be one of {:?}, got {:?}",
+            VALID_SNAPSHOT_SOURCES,
+            snapshot_source
+        );
+    }
+
+    let rows = read_library_db(library_db)?;
+    if rows.is_empty() {
+        log::warn!(
+            "populate_wxyc_library_v2: no rows from {}",
+            library_db.display()
+        );
+        return Ok(0);
+    }
+    let attempted = rows.len() as u64;
+
+    // Stage rows into a TEMP table via COPY, then INSERT ... ON CONFLICT
+    // from the temp into wxyc_library. This pattern lets us:
+    //   1. Use the fast COPY path for the bulk write.
+    //   2. Stamp `snapshot_at = now()` server-side (no chrono dep).
+    //   3. Apply ON CONFLICT (library_id) DO NOTHING on the merge so the
+    //      load is idempotent without per-row roundtrips.
+    let mut tx = client.transaction().context("begin tx")?;
+    tx.batch_execute(
+        "CREATE TEMP TABLE _wxyc_library_stage (
+            library_id   integer PRIMARY KEY,
+            artist_id    integer,
+            artist_name  text NOT NULL,
+            album_title  text NOT NULL,
+            label_id     integer,
+            label_name   text,
+            format_id    integer,
+            format_name  text,
+            wxyc_genre   text,
+            call_letters text,
+            call_numbers integer,
+            release_year smallint,
+            norm_artist  text NOT NULL,
+            norm_title   text NOT NULL,
+            norm_label   text
+        ) ON COMMIT DROP",
+    )?;
+
+    {
+        let mut writer = tx.copy_in(
+            "COPY _wxyc_library_stage (\
+                library_id, artist_id, artist_name, album_title, \
+                label_id, label_name, format_id, format_name, \
+                wxyc_genre, call_letters, call_numbers, release_year, \
+                norm_artist, norm_title, norm_label\
+             ) FROM STDIN WITH (FORMAT text, NULL '\\N')",
+        )?;
+        for r in &rows {
+            // norm_artist / norm_title are NOT NULL per §3.1; the normalizer
+            // collapses to a non-empty string for any non-empty input. We
+            // do not paper over an empty result here — if an empty artist or
+            // title slipped in upstream, the NOT NULL on the staging table
+            // will reject the row and surface the upstream issue.
+            let norm_artist = to_identity_match_form(&r.artist_name);
+            let norm_title = to_identity_match_form_title(&r.album_title);
+            let norm_label_v = norm_label(r.label_name.as_deref());
+            writeln!(
+                writer,
+                "{lib_id}\t\\N\t{artist}\t{title}\t\\N\t{label}\t\\N\t{fmt}\t{genre}\t{call_letters}\t{call_numbers}\t\\N\t{n_artist}\t{n_title}\t{n_label}",
+                lib_id = r.library_id,
+                artist = tsv_escape(&strip_nul(&r.artist_name)),
+                title = tsv_escape(&strip_nul(&r.album_title)),
+                label = tsv_escape_opt(strip_nul_opt(r.label_name.as_deref()).as_deref()),
+                fmt = tsv_escape_opt(strip_nul_opt(r.format_name.as_deref()).as_deref()),
+                genre = tsv_escape_opt(strip_nul_opt(r.wxyc_genre.as_deref()).as_deref()),
+                call_letters = tsv_escape_opt(strip_nul_opt(r.call_letters.as_deref()).as_deref()),
+                call_numbers = r
+                    .call_numbers
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "\\N".to_string()),
+                n_artist = tsv_escape(&strip_nul(&norm_artist)),
+                n_title = tsv_escape(&strip_nul(&norm_title)),
+                n_label = tsv_escape_opt(norm_label_v.as_deref()),
+            )?;
+        }
+        writer.finish()?;
+    }
+
+    let merge_sql = "INSERT INTO wxyc_library (\
+            library_id, artist_id, artist_name, album_title, \
+            label_id, label_name, format_id, format_name, \
+            wxyc_genre, call_letters, call_numbers, release_year, \
+            norm_artist, norm_title, norm_label, \
+            snapshot_at, snapshot_source\
+         ) \
+         SELECT library_id, artist_id, artist_name, album_title, \
+                label_id, label_name, format_id, format_name, \
+                wxyc_genre, call_letters, call_numbers, release_year, \
+                norm_artist, norm_title, norm_label, \
+                now(), $1 \
+         FROM _wxyc_library_stage \
+         ON CONFLICT (library_id) DO NOTHING";
+    tx.execute(merge_sql, &[&snapshot_source])?;
+    tx.commit()?;
+
+    log::info!(
+        "populate_wxyc_library_v2: wrote {attempted} rows (snapshot_source={snapshot_source}, normalizer={NORMALIZER_NAME})"
+    );
+    Ok(attempted)
+}
+
+/// Escape a string for PG COPY FORMAT text.
+///
+/// PG COPY's text format reserves backslash, tab, newline, and carriage
+/// return. We escape those; everything else passes through as-is. NUL has
+/// already been stripped at the [`strip_nul`] boundary above.
+fn tsv_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn tsv_escape_opt(s: Option<&str>) -> String {
+    match s {
+        None => "\\N".to_string(),
+        Some(v) => tsv_escape(v),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizer_name_audit_constant_is_pinned() {
+        // This pin protects the cross-cache audit trail: discogs-etl's
+        // loaders/wxyc.py emits the same string in INFO logs. A rename in
+        // wxyc_etl::text would otherwise drift silently.
+        assert_eq!(NORMALIZER_NAME, "wxyc_etl::text::to_identity_match_form");
+    }
+
+    #[test]
+    fn snapshot_source_vocabulary_matches_check_constraint() {
+        // Mirrors §3.1's CHECK (snapshot_source IN ('backend','tubafrenzy','llm')).
+        // If the vocabulary ever expands, both this constant AND the schema
+        // CHECK must change in lock-step.
+        assert_eq!(VALID_SNAPSHOT_SOURCES, &["backend", "tubafrenzy", "llm"]);
+    }
+
+    #[test]
+    fn tsv_escape_handles_reserved_characters() {
+        assert_eq!(tsv_escape("plain"), "plain");
+        assert_eq!(tsv_escape("with\ttab"), "with\\ttab");
+        assert_eq!(tsv_escape("with\nlf"), "with\\nlf");
+        assert_eq!(tsv_escape("back\\slash"), "back\\\\slash");
+    }
+
+    #[test]
+    fn norm_label_returns_none_for_none() {
+        assert!(norm_label(None).is_none());
+    }
+
+    #[test]
+    fn norm_label_normalizes_some() {
+        // "Sonamos" should fold to lowercase via the locked-on baseline.
+        assert_eq!(norm_label(Some("Sonamos")).as_deref(), Some("sonamos"));
+    }
+
+    #[test]
+    fn strip_nul_removes_u0000() {
+        assert_eq!(strip_nul("clean"), "clean");
+        assert_eq!(strip_nul("hello\0world"), "helloworld");
+    }
+}

--- a/tests/wxyc_library_v2_test.rs
+++ b/tests/wxyc_library_v2_test.rs
@@ -1,0 +1,294 @@
+//! Integration tests for the v2 `wxyc_library` cross-cache identity hook
+//! (E1 §4.1.2 of plans/library-hook-canonicalization.md).
+//!
+//! Validates the schema mirror in `schema/create_database.sql` +
+//! `schema/create_indexes.sql` (applied via `apply_schema()` +
+//! `create_indexes()`) plus the `populate_wxyc_library_v2()` loader from
+//! `src/wxyc_loader.rs`. Per the wiki §4.1.2, this cache has legacy
+//! production data; the dual-write window is implicit (the legacy hook
+//! data already exists out-of-band and our writes target the new
+//! `wxyc_library` table independently).
+//!
+//! Gated on `--ignored` per repo convention (`cargo test -- --ignored
+//! --test-threads=1`); requires PostgreSQL on port 5434 (`docker compose
+//! up -d`).
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use musicbrainz_cache::wxyc_loader::{populate_wxyc_library_v2, NORMALIZER_NAME};
+use wxyc_etl::text::{to_identity_match_form, to_identity_match_form_title};
+
+const DEFAULT_DB_URL: &str = "postgresql://musicbrainz:musicbrainz@localhost:5434/musicbrainz";
+
+fn db_url() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| DEFAULT_DB_URL.to_string())
+}
+
+/// Connect to PG and apply the cache schema (creates `wxyc_library` via the
+/// dual-source mirror in `schema/create_database.sql`). Drops any prior
+/// `wxyc_library` table first so each test starts clean.
+fn fresh_client() -> postgres::Client {
+    let mut client = postgres::Client::connect(&db_url(), postgres::NoTls).expect("connect");
+    // Drop just our table — leaves the rest of the cache schema alone so
+    // multiple tests can share a DB if run with --test-threads=1.
+    client
+        .batch_execute("DROP TABLE IF EXISTS wxyc_library CASCADE")
+        .expect("drop wxyc_library");
+    musicbrainz_cache::schema::apply_schema(&mut client).expect("apply_schema");
+    musicbrainz_cache::schema::create_indexes(&mut client).expect("create_indexes");
+    client
+}
+
+/// Fixture rows mirror discogs-etl's #178 `_FIXTURE_ROWS` so the two repos'
+/// integration tests stay in lockstep. Includes "Nilüfer Yanya" to exercise
+/// the diacritic-fold path through the storage layer end-to-end.
+const FIXTURE_ROWS: &[(i32, &str, &str, &str, &str, &str)] = &[
+    (1, "Juana Molina", "DOGA", "LP", "Sonamos", "Rock"),
+    (
+        2,
+        "Jessica Pratt",
+        "On Your Own Love Again",
+        "LP",
+        "Drag City",
+        "Rock",
+    ),
+    (
+        3,
+        "Chuquimamani-Condori",
+        "Edits",
+        "CD",
+        "self-released",
+        "Electronic",
+    ),
+    (
+        4,
+        "Duke Ellington & John Coltrane",
+        "Duke Ellington & John Coltrane",
+        "LP",
+        "Impulse Records",
+        "Jazz",
+    ),
+    (5, "Stereolab", "Aluminum Tunes", "CD", "Duophonic", "Rock"),
+    // Diacritic-bearing canonical name from wxyc-shared's
+    // wxycCanonicalArtistNames. Exercises the diacritic-fold path
+    // (ü -> u) end-to-end through the loader's normalization.
+    (6, "Nilüfer Yanya", "Painless", "LP", "ATO Records", "Rock"),
+];
+
+static FIXTURE_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// Build a per-test SQLite library.db in a unique temp path. Each test gets
+/// its own file so concurrent runs (or sequential runs that leak temp files)
+/// don't collide.
+fn build_library_db() -> PathBuf {
+    let dir = tempfile::tempdir().expect("tempdir").keep();
+    // Use both an atomic counter and the wall clock so paths are unique
+    // across processes and across re-runs.
+    let now_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let n = FIXTURE_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = dir.join(format!("library-{now_nanos}-{n}.db"));
+    let conn = rusqlite::Connection::open(&path).expect("open sqlite");
+    conn.execute_batch(
+        "CREATE TABLE library (
+            id INTEGER PRIMARY KEY,
+            artist TEXT NOT NULL,
+            title TEXT NOT NULL,
+            format TEXT,
+            label TEXT,
+            genre TEXT
+        )",
+    )
+    .expect("create library");
+    {
+        let mut stmt = conn
+            .prepare(
+                "INSERT INTO library (id, artist, title, format, label, genre) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .expect("prepare insert");
+        for (id, artist, title, format, label, genre) in FIXTURE_ROWS {
+            stmt.execute(rusqlite::params![id, artist, title, format, label, genre])
+                .expect("insert fixture row");
+        }
+    }
+    path
+}
+
+#[test]
+#[ignore] // Requires PostgreSQL: cargo test -- --ignored --test-threads=1
+fn schema_lands_all_expected_indexes() {
+    let mut client = fresh_client();
+    let expected_indexes: &[&str] = &[
+        "wxyc_library_pkey",
+        "wxyc_library_norm_artist_idx",
+        "wxyc_library_norm_title_idx",
+        "wxyc_library_artist_id_idx",
+        "wxyc_library_format_id_idx",
+        "wxyc_library_release_year_idx",
+        "wxyc_library_norm_artist_trgm_idx",
+        "wxyc_library_norm_title_trgm_idx",
+    ];
+    let rows = client
+        .query(
+            "SELECT indexname FROM pg_indexes \
+             WHERE schemaname = 'public' AND tablename = 'wxyc_library'",
+            &[],
+        )
+        .expect("select indexes");
+    let present: std::collections::HashSet<String> =
+        rows.iter().map(|r| r.get::<_, String>(0)).collect();
+    for &idx in expected_indexes {
+        assert!(
+            present.contains(idx),
+            "missing index {idx}; present: {present:?}"
+        );
+    }
+}
+
+#[test]
+#[ignore] // Requires PostgreSQL: cargo test -- --ignored --test-threads=1
+fn loader_writes_every_fixture_row() {
+    let mut client = fresh_client();
+    let library_db = build_library_db();
+
+    let attempted = populate_wxyc_library_v2(&mut client, &library_db, "backend")
+        .expect("populate_wxyc_library_v2");
+    assert_eq!(attempted, FIXTURE_ROWS.len() as u64);
+
+    let rows = client
+        .query(
+            "SELECT library_id, artist_name, album_title, norm_artist, norm_title, snapshot_source \
+             FROM wxyc_library ORDER BY library_id",
+            &[],
+        )
+        .expect("select wxyc_library");
+
+    let expected_ids: std::collections::HashSet<i32> = FIXTURE_ROWS.iter().map(|r| r.0).collect();
+    let present_ids: std::collections::HashSet<i32> =
+        rows.iter().map(|r| r.get::<_, i32>(0)).collect();
+    assert_eq!(present_ids, expected_ids);
+
+    for row in &rows {
+        let library_id: i32 = row.get(0);
+        let artist_name: String = row.get(1);
+        let album_title: String = row.get(2);
+        let norm_artist: String = row.get(3);
+        let norm_title: String = row.get(4);
+        let snapshot_source: String = row.get(5);
+        assert!(
+            !artist_name.is_empty(),
+            "artist_name empty for {library_id}"
+        );
+        assert!(
+            !album_title.is_empty(),
+            "album_title empty for {library_id}"
+        );
+        assert!(
+            !norm_artist.is_empty(),
+            "norm_artist empty for {library_id}"
+        );
+        assert!(!norm_title.is_empty(), "norm_title empty for {library_id}");
+        assert_eq!(
+            snapshot_source, "backend",
+            "snapshot_source for {library_id} was {snapshot_source:?}"
+        );
+    }
+}
+
+#[test]
+#[ignore] // Requires PostgreSQL: cargo test -- --ignored --test-threads=1
+fn loader_is_idempotent() {
+    let mut client = fresh_client();
+    let library_db = build_library_db();
+
+    let first = populate_wxyc_library_v2(&mut client, &library_db, "backend").expect("first run");
+    let second = populate_wxyc_library_v2(&mut client, &library_db, "backend").expect("second run");
+    // Both report rows-attempted (pre-conflict).
+    assert_eq!(first, second);
+    assert_eq!(first, FIXTURE_ROWS.len() as u64);
+
+    // Idempotency is observable in COUNT(*), not the return value.
+    let count: i64 = client
+        .query_one("SELECT COUNT(*) FROM wxyc_library", &[])
+        .expect("count")
+        .get(0);
+    assert_eq!(count, FIXTURE_ROWS.len() as i64);
+}
+
+#[test]
+#[ignore] // Requires PostgreSQL: cargo test -- --ignored --test-threads=1
+fn loader_rejects_invalid_snapshot_source() {
+    let mut client = fresh_client();
+    let library_db = build_library_db();
+    // The loader's argument check fires before any write, mirroring the
+    // §3.1 CHECK constraint vocabulary. We don't get as far as the DB.
+    let err = populate_wxyc_library_v2(&mut client, &library_db, "bogus")
+        .expect_err("bogus snapshot_source must error");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("snapshot_source"),
+        "expected snapshot_source error, got: {msg}"
+    );
+}
+
+#[test]
+#[ignore] // Requires PostgreSQL: cargo test -- --ignored --test-threads=1
+fn normalizer_pin_includes_diacritic_fold() {
+    let mut client = fresh_client();
+    let library_db = build_library_db();
+    populate_wxyc_library_v2(&mut client, &library_db, "backend").expect("populate");
+
+    // Audit string mirrors the discogs-etl loader's NORMALIZER_NAME so the
+    // cross-cache audit trail stays consistent.
+    assert_eq!(NORMALIZER_NAME, "wxyc_etl::text::to_identity_match_form");
+
+    // Library row 1: "Juana Molina" / "DOGA" / "Sonamos" — no diacritics,
+    // just lowercase. Hard-coded value pin catches drift in wxyc-etl's
+    // identity normalizer (the property assertion below would pass even if
+    // both sides changed in lockstep).
+    let row = client
+        .query_one(
+            "SELECT artist_name, album_title, label_name, norm_artist, norm_title, norm_label \
+             FROM wxyc_library WHERE library_id = 1",
+            &[],
+        )
+        .expect("row 1");
+    let artist: String = row.get(0);
+    let title: String = row.get(1);
+    let label: String = row.get(2);
+    let norm_artist: String = row.get(3);
+    let norm_title: String = row.get(4);
+    let norm_label: String = row.get(5);
+    assert_eq!(norm_artist, to_identity_match_form(&artist));
+    assert_eq!(norm_title, to_identity_match_form_title(&title));
+    assert_eq!(norm_label, to_identity_match_form(&label));
+    assert_eq!(norm_artist, "juana molina");
+    assert_eq!(norm_title, "doga");
+    assert_eq!(norm_label, "sonamos");
+
+    // Library row 6: "Nilüfer Yanya" — exercises the ü -> u diacritic-fold
+    // path through storage. Property assertion (no hard-coded value)
+    // because the rest of the title-side algorithm could legitimately
+    // evolve without breaking the diacritic-fold contract.
+    let row6: String = client
+        .query_one(
+            "SELECT norm_artist FROM wxyc_library WHERE library_id = 6",
+            &[],
+        )
+        .expect("row 6")
+        .get(0);
+    assert!(
+        !row6.contains('ü'),
+        "diacritic survived normalization: {row6:?}"
+    );
+    assert_eq!(
+        row6.to_lowercase(),
+        row6,
+        "normalization should lowercase: {row6:?}"
+    );
+}

--- a/tests/wxyc_library_v2_test.rs
+++ b/tests/wxyc_library_v2_test.rs
@@ -238,6 +238,49 @@ fn loader_rejects_invalid_snapshot_source() {
 
 #[test]
 #[ignore] // Requires PostgreSQL: cargo test -- --ignored --test-threads=1
+fn loader_rejects_empty_artist_or_title() {
+    // Postgres `NOT NULL` rejects SQL NULL but NOT empty strings; without
+    // the explicit guard in the COPY loop, a library.db row with an empty
+    // artist would silently land with an empty norm_artist and defeat
+    // downstream NULL-aware joins. Pin the loud-failure behavior.
+    use rusqlite::Connection as SqliteConnection;
+    use tempfile::TempDir;
+
+    let mut client = fresh_client();
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("library.db");
+    let conn = SqliteConnection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE library (\
+            id INTEGER PRIMARY KEY, \
+            artist TEXT NOT NULL, \
+            title TEXT NOT NULL\
+        );",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO library (id, artist, title) VALUES (?, ?, ?)",
+        rusqlite::params![1_i64, "", "Some Title"],
+    )
+    .unwrap();
+    drop(conn);
+
+    let err = populate_wxyc_library_v2(&mut client, &db_path, "backend")
+        .expect_err("empty artist must error");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("artist_name or album_title is empty"),
+        "expected empty-input error, got: {msg}"
+    );
+    let count: i64 = client
+        .query_one("SELECT COUNT(*) FROM wxyc_library", &[])
+        .unwrap()
+        .get(0);
+    assert_eq!(count, 0, "loader must not write any rows when bailing");
+}
+
+#[test]
+#[ignore] // Requires PostgreSQL: cargo test -- --ignored --test-threads=1
 fn normalizer_pin_includes_diacritic_fold() {
     let mut client = fresh_client();
     let library_db = build_library_db();


### PR DESCRIPTION
## Summary

- Lands the consolidated `wxyc_library` schema per [§3.1](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization.md#31-the-library-hook) on the Homebrew musicbrainz cache (port 5432). E1 §4.1.2 of the cross-cache-identity rollout. Schema validated by [WXYC/discogs-etl#185](https://github.com/WXYC/discogs-etl/pull/185).
- New module `src/wxyc_loader.rs` writes from `library.db` to `wxyc_library` via TEMP-table COPY + `INSERT … ON CONFLICT (library_id) DO NOTHING`. Normalizes via `wxyc_etl::text::to_identity_match_form{,_title}` (locked-on baseline, NOT `to_match_form`).
- Wired as new `import-wxyc-library` subcommand. 5 pg-marked integration tests (schema, write-every-row, idempotency, snapshot_source CHECK, normalizer pin including Nilüfer Yanya diacritic-fold).

## Decisions flagged for review

1. **CONCURRENTLY deviation (`migrations/0003_wxyc_library_v2.sql:20-40`)**: §4.1.2 calls for indexes built `CONCURRENTLY`. sqlx-postgres sends every migration as a single simple-Query batch, which PG treats as one implicit transaction — `CREATE INDEX CONCURRENTLY` refuses any transaction context. The Rust/sqlx equivalent of #185's psycopg-autocommit pattern is splitting into N one-statement no-transaction migrations — heavyweight wrapping for a brand-new empty table. Used plain `CREATE INDEX IF NOT EXISTS` instead: equivalent on first apply (empty table = no contention), short-circuits on re-apply. Documented in-file with a clear escape hatch for future populated-table index additions.
2. **Did NOT reuse `filter::load_library_artists`** — it returns `HashSet<String>` of normalized artist names only, dropping per-row IDs/titles/labels/formats. Wrote a parallel `read_library_db` adapter (mirrors discogs-etl's pattern). [WXYC/wxyc-etl#106](https://github.com/WXYC/wxyc-etl/issues/106) is the centralization follow-up.
3. **Duplicated `strip_nul`** rather than refactoring `import.rs` (which the issue explicitly forbids). 6-line function with a comment pointing at the policy source.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings -A clippy::manual_is_multiple_of` — clean
- [x] `cargo test` — unit tests pass
- [x] `cargo test -- --ignored --test-threads=1` against PG :5434 — 5 new + existing integration green
- [x] `sqlx migrate run` against fresh DB applies cleanly; idempotent on re-run

Closes #47