### PR TITLE
ci: pin workflow-level GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/charset-corpus-drift.yml
+++ b/.github/workflows/charset-corpus-drift.yml
@@ -12,6 +12,13 @@ on:
   schedule:
     - cron: '17 8 * * 1'
 
+# Workflow-level GITHUB_TOKEN scope. The reusable workflow runs
+# `npm pack @wxyc/shared` against npm.pkg.github.com using the token
+# forwarded as `npm-token`, which needs packages:read.
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   drift:
     uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
+# comments on PRs, or creates releases; all writes to external services
+# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -15,6 +15,12 @@ on:
         type: boolean
         default: false
 
+# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
+# comments on PRs, or creates releases; all writes to external services
+# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+permissions:
+  contents: read
+
 jobs:
   rebuild:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #54.

Adds a top-level `permissions:` block to every workflow so the GITHUB_TOKEN runs with a least-privilege scope pinned in code, instead of inheriting whatever the repo-wide default happens to be.

- `ci.yml`: contents: read
- `charset-corpus-drift.yml`: contents: read + packages: read
- `rebuild-cache.yml`: contents: read

Behavior-neutral today (no job writes via GITHUB_TOKEN beyond what the block grants) but pins the safe posture so future jobs can't silently inherit write scopes.

Part of the org-wide GitHub Actions hardening project (Phase 3).