### PR TITLE
chore: bump wxyc-etl to 0.6.0; add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      wxyc:
+        patterns:
+          - "wxyc-*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,9 +3384,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8692087abc2998a8ef2f1a872059b0ff8bbd2e9da6c75e108fa86cc752dee9e"
+checksum = "ef019673a0efa28a07fef1836af299c0d8a5988b3045980fd8a5a8fe353ecac7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "musicbrainz-cache"
 path = "src/main.rs"
 
 [dependencies]
-wxyc-etl = "0.4.0"
+wxyc-etl = "0.6.0"
 postgres = "0.19"
 rusqlite = { version = "0.31", features = ["bundled"] }
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/wxyc-etl-pin.txt
+++ b/wxyc-etl-pin.txt
@@ -17,4 +17,4 @@ unaccent_rules_version = 0.1.0
 unaccent_rules_sha256  = fc51eceb722904fa0d80734d4b2f4bbcffb0fcfecc133450f774210a067b9d26
 functions_sql_sha256   = 4beb7db2b44d479a4878a386e4d1b626d26fd3738e34371b23abe1ab4ccdc21a
 fixture_csv_sha256     = dc07253b12dab04bc008a23464d7cb5904953649fca49ae08c0104c89c99771a
-wxyc_etl_version       = 0.4.0
+wxyc_etl_version       = 0.6.0


### PR DESCRIPTION
## Summary

- Bump `wxyc-etl` from 0.4.0 to 0.6.0 to catch up to the current substrate.
- Bump `wxyc-etl-pin.txt` version label (vendored bytes unchanged).
- Add `.github/dependabot.yml` so future `wxyc-etl` bumps land here as weekly grouped PRs.

The wxyc-etl APIs this repo consumes (`text::to_match_form`, `schema::musicbrainz`, `logger::init`) are unchanged at their public boundary across 0.4.0 → 0.6.0, and the vendored plpgsql sources under `vendor/wxyc-etl/` are byte-identical between the two tags. No code or SHA changes needed.

## Test plan

- [x] `cargo check` clean
- [x] `cargo test` — all non-PG tests pass (PG-gated tests require `docker compose up -d`; CI's `test-postgres` job covers them)
- [x] `cargo clippy -- -D warnings -A clippy::manual_is_multiple_of` clean
- [x] `cargo fmt --check` clean
- [x] Parity test (`pin_file_sha256s_match_vendored_files`, `migration_inlines_canonical_sql_byte_for_byte`) passes
- [ ] CI green