### PR TITLE
chore(deps): consolidate NUL-strip onto wxyc_etl::pg::to_pg_text_form

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "musicbrainz-cache"
 path = "src/main.rs"
 
 [dependencies]
-wxyc-etl = "0.6.0"
+wxyc-etl = "0.8"
 postgres = "0.19"
 rusqlite = { version = "0.31", features = ["bundled"] }
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,21 +1,7 @@
 use anyhow::Context;
-use std::borrow::Cow;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
-
-/// Strip U+0000 (NUL) bytes from a string before writing to a PG TEXT column.
-///
-/// PostgreSQL TEXT does not accept U+0000 (SQL standard). Per the org-wide
-/// policy in WXYC/docs#18, every PG TEXT write boundary strips NUL — U+0000
-/// in metadata is corruption, never intent. Returns `Cow::Borrowed` when no
-/// NUL is present so the common case avoids allocating.
-fn strip_nul(s: &str) -> Cow<'_, str> {
-    if s.contains('\0') {
-        Cow::Owned(s.replace('\0', ""))
-    } else {
-        Cow::Borrowed(s)
-    }
-}
+use wxyc_etl::pg::to_pg_text_form;
 
 /// Mapping from a MusicBrainz dump file to our schema.
 ///
@@ -207,8 +193,8 @@ pub fn import_table(
             if j > 0 {
                 buf.push(b'\t');
             }
-            // strip NUL per WXYC/docs#18 — see strip_nul docstring.
-            buf.extend_from_slice(strip_nul(val).as_bytes());
+            // strip NUL per WXYC/docs#18; contract is in wxyc_etl::pg::to_pg_text_form.
+            buf.extend_from_slice(to_pg_text_form(val).as_bytes());
         }
         buf.push(b'\n');
         row_count += 1;
@@ -262,44 +248,4 @@ pub fn import_all(client: &mut postgres::Client, data_dir: &Path) -> anyhow::Res
         elapsed.as_secs_f64()
     );
     Ok(total)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn strip_nul_borrowed_when_clean() {
-        let result = strip_nul("Stereolab");
-        assert_eq!(&*result, "Stereolab");
-        assert!(matches!(result, Cow::Borrowed(_)));
-    }
-
-    #[test]
-    fn strip_nul_owned_when_nul_present() {
-        let result = strip_nul("a\0b");
-        assert_eq!(&*result, "ab");
-        assert!(matches!(result, Cow::Owned(_)));
-    }
-
-    #[test]
-    fn strip_nul_drops_all_nuls() {
-        assert_eq!(&*strip_nul("\0a\0b\0"), "ab");
-    }
-
-    #[test]
-    fn strip_nul_empty_passthrough() {
-        let result = strip_nul("");
-        assert_eq!(&*result, "");
-        assert!(matches!(result, Cow::Borrowed(_)));
-    }
-
-    #[test]
-    fn strip_nul_idempotent() {
-        let once = strip_nul("a\0b\0c");
-        assert_eq!(&*once, "abc");
-        let twice = strip_nul(&once);
-        assert_eq!(&*twice, "abc");
-        assert!(matches!(twice, Cow::Borrowed(_)));
-    }
 }

--- a/src/wxyc_loader.rs
+++ b/src/wxyc_loader.rs
@@ -36,6 +36,7 @@
 use anyhow::Context;
 use std::io::Write;
 use std::path::Path;
+use wxyc_etl::pg::to_pg_text_form;
 use wxyc_etl::text::{to_identity_match_form, to_identity_match_form_title};
 
 /// Snapshot-source vocabulary mirroring the §3.1 CHECK constraint.
@@ -201,23 +202,6 @@ fn norm_label(label: Option<&str>) -> Option<String> {
     label.map(to_identity_match_form).filter(|s| !s.is_empty())
 }
 
-/// Strip U+0000 (NUL) bytes before writing to a PG TEXT column.
-///
-/// Mirrors `import.rs::strip_nul`. Per the org-wide WXYC/docs#18 policy,
-/// every PG TEXT write boundary strips NUL — U+0000 in metadata is
-/// corruption, never intent.
-fn strip_nul(s: &str) -> String {
-    if s.contains('\0') {
-        s.replace('\0', "")
-    } else {
-        s.to_owned()
-    }
-}
-
-fn strip_nul_opt(s: Option<&str>) -> Option<String> {
-    s.map(strip_nul)
-}
-
 /// Populate the consolidated `wxyc_library` hook from a SQLite library.db.
 ///
 /// Per E1 §4.1.2 + §3.1: every library row is written. Idempotent on
@@ -331,18 +315,26 @@ pub fn populate_wxyc_library_v2(
                 writer,
                 "{lib_id}\t\\N\t{artist}\t{title}\t\\N\t{label}\t\\N\t{fmt}\t{genre}\t{call_letters}\t{call_numbers}\t\\N\t{n_artist}\t{n_title}\t{n_label}",
                 lib_id = r.library_id,
-                artist = tsv_escape(&strip_nul(&r.artist_name)),
-                title = tsv_escape(&strip_nul(&r.album_title)),
-                label = tsv_escape_opt(strip_nul_opt(r.label_name.as_deref()).as_deref()),
-                fmt = tsv_escape_opt(strip_nul_opt(r.format_name.as_deref()).as_deref()),
-                genre = tsv_escape_opt(strip_nul_opt(r.wxyc_genre.as_deref()).as_deref()),
-                call_letters = tsv_escape_opt(strip_nul_opt(r.call_letters.as_deref()).as_deref()),
+                artist = tsv_escape(&to_pg_text_form(&r.artist_name)),
+                title = tsv_escape(&to_pg_text_form(&r.album_title)),
+                label = tsv_escape_opt(
+                    r.label_name.as_deref().map(to_pg_text_form).as_deref(),
+                ),
+                fmt = tsv_escape_opt(
+                    r.format_name.as_deref().map(to_pg_text_form).as_deref(),
+                ),
+                genre = tsv_escape_opt(
+                    r.wxyc_genre.as_deref().map(to_pg_text_form).as_deref(),
+                ),
+                call_letters = tsv_escape_opt(
+                    r.call_letters.as_deref().map(to_pg_text_form).as_deref(),
+                ),
                 call_numbers = r
                     .call_numbers
                     .map(|n| n.to_string())
                     .unwrap_or_else(|| "\\N".to_string()),
-                n_artist = tsv_escape(&strip_nul(&norm_artist)),
-                n_title = tsv_escape(&strip_nul(&norm_title)),
+                n_artist = tsv_escape(&to_pg_text_form(&norm_artist)),
+                n_title = tsv_escape(&to_pg_text_form(&norm_title)),
                 n_label = tsv_escape_opt(norm_label_v.as_deref()),
             )?;
         }
@@ -376,7 +368,7 @@ pub fn populate_wxyc_library_v2(
 ///
 /// PG COPY's text format reserves backslash, tab, newline, and carriage
 /// return. We escape those; everything else passes through as-is. NUL has
-/// already been stripped at the [`strip_nul`] boundary above.
+/// already been stripped at the [`to_pg_text_form`] boundary above.
 fn tsv_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for ch in s.chars() {
@@ -444,11 +436,5 @@ mod tests {
         // NULL-aware lookups on norm_label behave correctly.
         assert_eq!(norm_label(Some("")), None);
         assert_eq!(norm_label(Some("   ")), None);
-    }
-
-    #[test]
-    fn strip_nul_removes_u0000() {
-        assert_eq!(strip_nul("clean"), "clean");
-        assert_eq!(strip_nul("hello\0world"), "helloworld");
     }
 }


### PR DESCRIPTION
## Summary

Step 2 of the WX-3.B follow-up consumer sweep ([WXYC/wxyc-etl#142](https://github.com/WXYC/wxyc-etl/issues/142)). Replaces this repo's local `strip_nul` helpers with `wxyc_etl::pg::to_pg_text_form`, so the WXYC/docs#18 PG TEXT U+0000 strip policy lives in one place across the org.

## What changed

- `src/import.rs:12` — local `strip_nul` and its five unit tests at L272-303 are gone. The COPY-loop call-site at L211 uses the upstream helper. Contract is tested upstream in `wxyc-etl/src/pg/text.rs::tests`.
- `src/wxyc_loader.rs:209` — local `strip_nul` + `strip_nul_opt` and their unit test are gone. The eight call-sites in the `wxyc_library` COPY loop use the upstream helper. The `Option<&str>` sites use `Option::map(to_pg_text_form).as_deref()`, mirroring the new Python contract.
- `Cargo.toml` — `wxyc-etl = \"0.6.0\"` → `\"0.8\"`.

## Scope note — second helper not in the issue audit

The original [#142](https://github.com/WXYC/wxyc-etl/issues/142) table for this repo called out only `src/import.rs:12`. After cloning, I found a second `strip_nul` at `src/wxyc_loader.rs:209` added later during the cross-cache-identity rollout (E1 §4.1.2) and missed by the issue's audit. Both implement the same WXYC/docs#18 policy. Leaving the second behind would defeat the consolidation goal (\"policy lives in one place\"), so this PR sweeps both. If the reviewer prefers to split the `wxyc_loader.rs` portion into a follow-up, that's straightforward.

## CI dependency

This PR bumps to `wxyc-etl = \"0.8\"`. **CI will fail until [WXYC/wxyc-etl#143](https://github.com/WXYC/wxyc-etl/pull/143) merges and a `v0.8.0` tag publishes to crates.io.** The Rust crate API at `wxyc_etl::pg::to_pg_text_form` is unchanged from 0.7.0, so this PR is functionally complete today — it's only the version constraint that needs the publish.

## Test plan

- [x] `cargo test --lib` — 8 tests pass (locally verified with a `[patch.crates-io]` pointer at the 0.8.0 worktree; patch reverted before commit)
- [x] `cargo clippy -- -D warnings -A clippy::manual_is_multiple_of` clean
- [x] `cargo fmt --check` clean
- [ ] Integration tests (`-- --ignored --test-threads=1`) require PG on port 5434; will run in CI under the docker-compose service container
- [ ] CI green after [WXYC/wxyc-etl#143](https://github.com/WXYC/wxyc-etl/pull/143) publishes

Towards [WXYC/wxyc-etl#142](https://github.com/WXYC/wxyc-etl/issues/142).