### PR TITLE
ci: pin sqlx-cli to 0.8.6 in rebuild-cache workflow

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -49,7 +49,7 @@ jobs:
       # migrations added between monthly rebuilds get picked up here so
       # incremental schema changes don't require a 6-hour reimport.
       - name: Install sqlx-cli
-        run: cargo install --quiet --version 0.8 sqlx-cli --no-default-features --features postgres
+        run: cargo install --quiet --version 0.8.6 sqlx-cli --no-default-features --features postgres
       - name: Apply pending migrations
         run: sqlx migrate run --source migrations
         env:


### PR DESCRIPTION
## Summary

The monthly `rebuild-cache.yml` cron has been silently failing since 2026-04 because current cargo no longer accepts a bare `0.8` for `cargo install --version`. It now demands either an explicit SemVer range (`^0.8`) or a concrete version. Failed runs: 25365616222 (2026-05-05), 27008638719 (2026-06-05).

Pin to `0.8.6` (current latest in the 0.8.x line on crates.io) rather than `^0.8` so future cargo behavior changes don't silently break the cron again. `0.9.0` was just published; staying on 0.8.x preserves the previously-intended pin range.

Only one occurrence of the broken pattern in tracked files (rebuild-cache.yml:52). The other grep hit lives inside `.claude/worktrees/`, which is not tracked.

Closes #68

## Test plan

- [x] CI on this PR passes (no install step exercised here, but YAML stays valid).
- [ ] Production smoke: next scheduled run on 2026-07-05 06:00 UTC. The previous two monthly runs both died at the install step, so a green run end-to-end on the 5th is the real verification.
- [ ] Optional: kick off a `workflow_dispatch` against this branch (with `skip_download=true` if reusing existing data) before merge to short-circuit the wait.