### PR TITLE
fix(schema): use batch_execute for create_indexes; stop silently dropping comment-preceded indexes

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -40,18 +40,17 @@ pub fn drop_all_tables(client: &mut postgres::Client) -> anyhow::Result<()> {
 }
 
 /// Create secondary indexes from create_indexes.sql.
+///
+/// Delegates to `client.batch_execute`, which speaks the PG simple-query
+/// protocol and handles SQL comments + string-literal escaping correctly.
+/// The previous `split(';')` + `starts_with("--")` parser silently dropped
+/// any CREATE INDEX preceded by a leading `--` comment block — see
+/// WXYC/musicbrainz-cache#50.
 pub fn create_indexes(client: &mut postgres::Client) -> anyhow::Result<()> {
     let sql_path = Path::new(SCHEMA_DIR).join("create_indexes.sql");
     let sql = std::fs::read_to_string(&sql_path)
         .with_context(|| format!("Failed to read {}", sql_path.display()))?;
-
-    for statement in sql.split(';') {
-        let statement = statement.trim();
-        if statement.is_empty() || statement.starts_with("--") {
-            continue;
-        }
-        client.batch_execute(statement)?;
-    }
+    client.batch_execute(&sql)?;
     log::info!("Indexes created.");
     Ok(())
 }

--- a/tests/create_indexes_parser_regression_test.rs
+++ b/tests/create_indexes_parser_regression_test.rs
@@ -1,0 +1,123 @@
+//! Regression test for WXYC/musicbrainz-cache#50.
+//!
+//! The previous `create_indexes` implementation parsed
+//! `schema/create_indexes.sql` with `sql.split(';')` and skipped any chunk
+//! whose trimmed form started with `--`. That naive parser silently dropped
+//! every CREATE INDEX statement preceded by a leading `--` comment block,
+//! because the comment block lives in the same chunk as the next statement
+//! (the chunk boundary is the previous statement's `;`).
+//!
+//! Three indexes were latently dropped on fresh-build / DR rebuild paths:
+//! - `idx_mb_recording_gid` — preceded by the file header comment.
+//! - `idx_mb_artist_name_lower_trgm` — preceded by the 3-line "Trigram GIN
+//!   index supports the `%` similarity operator" comment block.
+//! - `idx_mb_artist_tag_artist` — preceded by the 6-line "The three
+//!   idx_mb_*_name_lower_trgm indexes immediately above mirror..." block.
+//!
+//! This test asserts all three exist on `pg_indexes` after a fresh
+//! `drop_all_tables` → `apply_schema` → `create_indexes` cycle. Under the
+//! old code path the test FAILS for all three.
+//!
+//! Mirrors the gating and fresh-client setup of
+//! `tests/external_search_trgm_test.rs` (same `#[ignore]` + `DB_LOCK`
+//! pattern; `--test-threads=1` coordinates the cross-binary case).
+
+use musicbrainz_cache::schema;
+use postgres::{Client, NoTls};
+use std::sync::{Mutex, MutexGuard};
+
+const DEFAULT_DB_URL: &str = "postgresql://musicbrainz:musicbrainz@localhost:5434/musicbrainz";
+
+fn db_url() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| DEFAULT_DB_URL.to_string())
+}
+
+static DB_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_db() -> MutexGuard<'static, ()> {
+    DB_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn fresh_client() -> Client {
+    let mut client = Client::connect(&db_url(), NoTls)
+        .expect("Failed to connect to test DB; is `docker compose up -d` running?");
+    schema::drop_all_tables(&mut client).expect("drop_all_tables");
+    schema::apply_schema(&mut client).expect("apply_schema");
+    schema::create_indexes(&mut client).expect("create_indexes");
+    client
+}
+
+/// Indexes the OLD `split(';')` parser silently dropped because the file
+/// places `--` comment blocks immediately before each statement.
+const PREVIOUSLY_DROPPED_INDEXES: &[&str] = &[
+    "idx_mb_recording_gid",
+    "idx_mb_artist_name_lower_trgm",
+    "idx_mb_artist_tag_artist",
+];
+
+#[test]
+#[ignore] // Requires PostgreSQL: cargo test -- --ignored --test-threads=1
+fn test_create_indexes_no_longer_drops_comment_preceded_indexes() {
+    let _lock = lock_db();
+    let mut client = fresh_client();
+
+    let expected_vec: Vec<&str> = PREVIOUSLY_DROPPED_INDEXES.to_vec();
+    let rows = client
+        .query(
+            "SELECT indexname FROM pg_indexes \
+             WHERE schemaname = 'public' \
+             AND indexname = ANY($1::text[]) \
+             ORDER BY indexname",
+            &[&expected_vec],
+        )
+        .expect("pg_indexes query");
+    let found: Vec<String> = rows.iter().map(|r| r.get::<_, String>(0)).collect();
+    let mut expected_sorted: Vec<&str> = PREVIOUSLY_DROPPED_INDEXES.to_vec();
+    expected_sorted.sort();
+    assert_eq!(
+        found, expected_sorted,
+        "create_indexes must apply every CREATE INDEX in schema/create_indexes.sql, \
+         including statements preceded by `--` comment blocks. \
+         Expected {expected_sorted:?}, found {found:?}. \
+         If indexes are missing, src/schema.rs::create_indexes is likely back to \
+         naively split(';')-parsing the file — use client.batch_execute instead \
+         (see WXYC/musicbrainz-cache#50)."
+    );
+}
+
+/// Specifically pin `idx_mb_artist_name_lower_trgm` — the example called
+/// out in the issue's acceptance criteria. Adds a property check (must be a
+/// GIN trgm index on `lower(name)`) on top of the existence check above, so
+/// if someone "fixes" the parser by emitting a no-op CREATE INDEX with the
+/// right name but wrong shape, this still catches it.
+#[test]
+#[ignore] // Requires PostgreSQL: cargo test -- --ignored --test-threads=1
+fn test_idx_mb_artist_name_lower_trgm_is_gin_trgm_on_lower_name() {
+    let _lock = lock_db();
+    let mut client = fresh_client();
+
+    let row = client
+        .query_one(
+            "SELECT indexdef FROM pg_indexes \
+             WHERE schemaname = 'public' AND indexname = $1",
+            &[&"idx_mb_artist_name_lower_trgm"],
+        )
+        .expect(
+            "idx_mb_artist_name_lower_trgm missing after create_indexes — \
+             the naive split(';') parser regression has returned",
+        );
+    let indexdef: String = row.get(0);
+    let lower = indexdef.to_lowercase();
+    assert!(
+        lower.contains("using gin"),
+        "idx_mb_artist_name_lower_trgm should be a GIN index, got: {indexdef}"
+    );
+    assert!(
+        indexdef.contains("gin_trgm_ops"),
+        "idx_mb_artist_name_lower_trgm should use gin_trgm_ops, got: {indexdef}"
+    );
+    assert!(
+        lower.contains("lower(name)"),
+        "idx_mb_artist_name_lower_trgm should be on lower(name), got: {indexdef}"
+    );
+}


### PR DESCRIPTION
## Summary

`src/schema.rs::create_indexes` parsed `schema/create_indexes.sql` by splitting on `;` and skipping any chunk whose trimmed form started with `--`. Because the chunk boundary is the *previous* statement's semicolon, any `--` comment block placed immediately before a `CREATE INDEX` got glued to that statement; the parser then dropped the whole chunk **including the trailing `CREATE INDEX`**.

Three indexes were latently missing from fresh-build and DR-rebuild databases:

- `idx_mb_recording_gid` — dropped by the file's header comment (lines 1-5).
- `idx_mb_artist_name_lower_trgm` — dropped by the 3-line comment at `schema/create_indexes.sql` L12-14. This is the example called out in the issue.
- `idx_mb_artist_tag_artist` — dropped by the 6-line comment block at L23-28.

The `sqlx migrate run` path was unaffected because it uses a real SQL parser. Only the runtime `apply_schema → create_indexes` path was hit, so anyone going through migrations had the indexes; anyone going through the Rust pipeline's index step did not.

## Fix

Replace the naive parser with `client.batch_execute(&sql)` — the same shape `apply_schema` already uses. The PG simple-query protocol handles every form of SQL comment and string-literal escaping, so the three sharp edges enumerated in #50 (leading comment block, `;` inside `--`, unbalanced `'` inside `--`) all go away.

## Tests

New `tests/create_indexes_parser_regression_test.rs`:

- `test_create_indexes_no_longer_drops_comment_preceded_indexes` — asserts all three previously-dropped indexes exist in `pg_indexes` after `drop_all_tables → apply_schema → create_indexes`.
- `test_idx_mb_artist_name_lower_trgm_is_gin_trgm_on_lower_name` — pins the issue's named example with a shape assertion (GIN + `gin_trgm_ops` + `lower(name)`) so a future regression that emits a same-named no-op index doesn't slip past.

Both tests fail against the old `split(';')` parser (confirmed locally against the test DB) and pass against the new `batch_execute` path. Gating mirrors the analog `tests/external_search_trgm_test.rs` — `#[ignore]` + in-binary `DB_LOCK`, run via `cargo test -- --ignored --test-threads=1` in CI's `test-postgres` job.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -A clippy::manual_is_multiple_of`
- [x] `cargo test` (no-PG unit tests pass)
- [x] `cargo test --test create_indexes_parser_regression_test -- --ignored --test-threads=1` fails under old code, passes under new
- [x] `cargo test --test external_search_trgm_test -- --ignored --test-threads=1` still passes (analog regression unaffected)
- [x] `cargo test --test idempotency_test -- --ignored --test-threads=1` still passes
- [ ] CI green on the PR

Closes #50